### PR TITLE
Added TaskNameResolver and related implementation

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskConfiguration.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskConfiguration.java
@@ -27,7 +27,9 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.task.listener.TaskLifecycleListener;
+import org.springframework.cloud.task.repository.TaskNameResolver;
 import org.springframework.cloud.task.repository.TaskRepository;
+import org.springframework.cloud.task.repository.support.SimpleTaskNameResolver;
 import org.springframework.cloud.task.repository.support.TaskDatabaseInitializer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -76,12 +78,17 @@ public class SimpleTaskConfiguration {
 
 	@Bean
 	public TaskLifecycleListener taskLifecycleListener() {
-		return new TaskLifecycleListener(taskRepository());
+		return new TaskLifecycleListener(taskRepository(), taskNameResolver());
 	}
 
 	@Bean
 	public PlatformTransactionManager transactionManager() {
 		return this.transactionManager;
+	}
+
+	@Bean
+	public TaskNameResolver taskNameResolver() {
+		return new SimpleTaskNameResolver();
 	}
 
 	/**

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/TaskConfigurer.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/TaskConfigurer.java
@@ -33,9 +33,9 @@ public interface TaskConfigurer {
 	 *
 	 * @return A TaskRepository
 	 */
-	public TaskRepository getTaskRepository();
+	TaskRepository getTaskRepository();
 
-	public PlatformTransactionManager getTransactionManager();
+	PlatformTransactionManager getTransactionManager();
 
-	public TaskExplorer getTaskExplorer();
+	TaskExplorer getTaskExplorer();
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskNameResolver.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskNameResolver.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.task.repository;
+
+/**
+ * Strategy interface for customizing how the name of a task is determined.
+ *
+ * @author Michael Minella
+ */
+public interface TaskNameResolver {
+
+	/**
+	 * @return the name of the task being executed within this context.
+	 */
+	String getTaskName();
+}

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskNameResolver.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskNameResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.task.repository.support;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.task.repository.TaskNameResolver;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.util.StringUtils;
+
+/**
+ * Simple implementation of the {@link TaskNameResolver} interface.  Names the task based
+ * on the following order of precidence:
+ * <ol>
+ *    <li>A configured property <code>spring.cloud.task.name</code></li>
+ *    <li>The {@link ApplicationContext}'s id.</li>
+ * </ol>
+ *
+ * @author Michael Minella
+ * @see org.springframework.boot.context.ContextIdApplicationContextInitializer
+ */
+public class SimpleTaskNameResolver implements TaskNameResolver, ApplicationContextAware {
+
+	private ApplicationContext context;
+
+	private String configuredName;
+
+	@Value("${spring.cloud.task.name:}")
+	public void setConfiguredName(String configuredName) {
+		this.configuredName = configuredName;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.context = applicationContext;
+	}
+
+	@Override
+	public String getTaskName() {
+		if(StringUtils.hasText(configuredName)) {
+			return configuredName;
+		}
+		else {
+			return context.getId();
+		}
+	}
+}

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorerTests.java
@@ -35,8 +35,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 
-import javax.sql.DataSource;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,6 +42,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
@@ -54,7 +53,6 @@ import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
 import org.springframework.cloud.task.util.TestVerifierUtils;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -67,17 +65,11 @@ public class SimpleTaskExplorerTests {
 
 	private AnnotationConfigApplicationContext context;
 
-	@Autowired(required = false)
-	private DataSource dataSource;
-
 	@Autowired
 	private TaskExecutionDao dao;
 
 	@Autowired
 	private TaskExplorer taskExplorer;
-
-	@Autowired
-	private ResourceLoader resourceLoader;
 
 	private DaoType testType;
 

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskNameResolverTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskNameResolverTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.task.repository.support;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import org.springframework.context.support.GenericApplicationContext;
+
+/**
+ * @author Michael Minella
+ */
+public class SimpleTaskNameResolverTests {
+
+	@Test
+	public void testDefault() {
+		GenericApplicationContext context = new GenericApplicationContext();
+
+		SimpleTaskNameResolver taskNameResolver = new SimpleTaskNameResolver();
+		taskNameResolver.setApplicationContext(context);
+
+		assertTrue(taskNameResolver.getTaskName().startsWith("org.springframework.context.support.GenericApplicationContext"));
+	}
+
+	@Test
+	public void testApplicationName() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.setId("foo");
+
+		SimpleTaskNameResolver taskNameResolver = new SimpleTaskNameResolver();
+		taskNameResolver.setApplicationContext(context);
+
+		assertEquals("foo", taskNameResolver.getTaskName());
+	}
+
+	@Test
+	public void testExternalConfig() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.setId("foo");
+
+		SimpleTaskNameResolver taskNameResolver = new SimpleTaskNameResolver();
+		taskNameResolver.setApplicationContext(context);
+
+		taskNameResolver.setConfiguredName("bar");
+
+		assertEquals("bar", taskNameResolver.getTaskName());
+	}
+}

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/util/TestDefaultConfiguration.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/util/TestDefaultConfiguration.java
@@ -16,9 +16,11 @@
 
 package org.springframework.cloud.task.util;
 
-		import org.springframework.cloud.task.listener.TaskLifecycleListener;
+import org.springframework.cloud.task.listener.TaskLifecycleListener;
+import org.springframework.cloud.task.repository.TaskNameResolver;
 import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.cloud.task.repository.dao.MapTaskExecutionDao;
+import org.springframework.cloud.task.repository.support.SimpleTaskNameResolver;
 import org.springframework.cloud.task.repository.support.SimpleTaskRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,7 +39,12 @@ public class TestDefaultConfiguration {
 	}
 
 	@Bean
+	public TaskNameResolver taskNameResolver() {
+		return new SimpleTaskNameResolver();
+	}
+
+	@Bean
 	public TaskLifecycleListener taskHandler(){
-		return new TaskLifecycleListener(taskRepository());
+		return new TaskLifecycleListener(taskRepository(), taskNameResolver());
 	}
 }

--- a/spring-cloud-task-samples/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TaskApplication.java
+++ b/spring-cloud-task-samples/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TaskApplication.java
@@ -45,7 +45,7 @@ public class TaskApplication {
 	}
 
 	public static void main(String[] args) {
-		SpringApplication.run(TaskApplication.class);
+		SpringApplication.run(TaskApplication.class, args);
 	}
 
 	/**


### PR DESCRIPTION
TaskNameResolver allows the ability to customize how a task is named.
During normal use cases, the provided SimpleTaskNameResolver should
suffice.

resolves spring-cloud/spring-cloud-task#54