### PR TITLE
SCT-66 Fix for Task_Execution error

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/dao/JdbcTaskExecutionDao.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/dao/JdbcTaskExecutionDao.java
@@ -298,7 +298,7 @@ public class JdbcTaskExecutionDao implements TaskExecutionDao {
 	 * TASK_EXECUTION_PARAMS table.
 	 */
 	private void insertParameter(long executionId, String param) {
-		int[] argTypes = new int[]{ Types.VARCHAR, Types.VARCHAR };
+		int[] argTypes = new int[]{ Types.BIGINT, Types.VARCHAR };
 		Object[] args = new Object[]{ executionId, param };
 		jdbcTemplate.update(getQuery(CREATE_TASK_PARAMETER), args, argTypes);
 	}


### PR DESCRIPTION
Sets the argType for the task_execution_id in the Task_Execution_params to be a BIGINT (vs the VARCHAR)

resolves spring-cloud/spring-cloud-task#66