### PR TITLE
Use spring Boot events to get exit code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 				<!-- Import dependency management from Spring Boot -->
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>1.3.2.BUILD-SNAPSHOT</version>
+				<version>1.3.2.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskLifecycleListenerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskLifecycleListenerTests.java
@@ -99,6 +99,7 @@ public class TaskLifecycleListenerTests {
 		context.refresh();
 		RuntimeException exception = new RuntimeException("This was expected");
 		context.publishEvent(new ApplicationFailedEvent(new SpringApplication(), new String[0], context, exception));
+		context.publishEvent(new ContextClosedEvent(context));
 
 		verifyTaskExecution(0, true, 1, exception);
 	}

--- a/spring-cloud-task-samples/timestamp/pom.xml
+++ b/spring-cloud-task-samples/timestamp/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.0.RELEASE</version>
+		<version>1.3.2.RELEASE</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Spring Boot now provides the result of an ExitCodeExceptionMapper via an
event called ExitCodeEvent.  This commit takes advantage of this new
event.

Resolves spring-cloud/spring-cloud-task#48