### PR TITLE
SCT-82 Exit Code needs to be null while task is running

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
@@ -160,7 +160,7 @@ public class TaskLifecycleListener implements ApplicationListener<ApplicationEve
 			}
 
 			this.taskExecution = new TaskExecution(this.taskRepository.getNextExecutionId(),
-					0, this.taskNameResolver.getTaskName(), new Date(), null, null,
+					null, this.taskNameResolver.getTaskName(), new Date(), null, null,
 					args);
 
 			this.taskRepository.createTaskExecution(this.taskExecution);

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskExecution.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskExecution.java
@@ -37,7 +37,7 @@ public class TaskExecution {
 	/**
 	 * The recorded exit code for the task.
 	 */
-	private int exitCode;
+	private Integer exitCode;
 
 	/**
 	 * User defined name for the task.
@@ -68,7 +68,7 @@ public class TaskExecution {
 		parameters = new ArrayList<>();
 	}
 
-	public TaskExecution(long executionId, int exitCode, String taskName,
+	public TaskExecution(long executionId, Integer exitCode, String taskName,
 						 Date startTime, Date endTime,
 						 String exitMessage, List<String> parameters) {
 
@@ -87,11 +87,11 @@ public class TaskExecution {
 		return executionId;
 	}
 
-	public int getExitCode() {
+	public Integer getExitCode() {
 		return exitCode;
 	}
 
-	public void setExitCode(int exitCode) {
+	public void setExitCode(Integer exitCode) {
 		this.exitCode = exitCode;
 	}
 

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/dao/JdbcTaskExecutionDao.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/dao/JdbcTaskExecutionDao.java
@@ -324,7 +324,7 @@ public class JdbcTaskExecutionDao implements TaskExecutionDao {
 		public TaskExecution mapRow(ResultSet rs, int rowNum) throws SQLException {
 			long  id = rs.getLong("TASK_EXECUTION_ID");
 			TaskExecution taskExecution=new TaskExecution(id,
-					rs.getInt("EXIT_CODE"),
+					(Integer) rs.getObject("EXIT_CODE"),
 					rs.getString("TASK_NAME"),
 					rs.getTimestamp("START_TIME"),
 					rs.getTimestamp("END_TIME"),

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskLifecycleListenerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskLifecycleListenerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.task.listener;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -75,14 +76,14 @@ public class TaskLifecycleListenerTests {
 	@Test
 	public void testTaskCreate() {
 		context.refresh();
-		verifyTaskExecution(0, false, 0, null);
+		verifyTaskExecution(0, false, null, null);
 	}
 
 	@Test
 	public void testTaskCreateWithArgs() {
 		context.register(ArgsConfiguration.class);
 		context.refresh();
-		verifyTaskExecution(2, false, 0, null);
+		verifyTaskExecution(2, false, null, null);
 	}
 
 	@Test
@@ -113,7 +114,7 @@ public class TaskLifecycleListenerTests {
 		return writer.toString();
 	}
 
-	private void verifyTaskExecution(int numberOfParams, boolean update, int exitCode, Throwable exception) {
+	private void verifyTaskExecution(int numberOfParams, boolean update, Integer exitCode, Throwable exception) {
 		this.taskExplorer = context.getBean(TaskExplorer.class);
 
 		Sort sort = new Sort("id");
@@ -137,9 +138,11 @@ public class TaskLifecycleListenerTests {
 
 		if(update) {
 			assertTrue(taskExecution.getEndTime().getTime() >= taskExecution.getStartTime().getTime());
+			assertNotNull(taskExecution.getExitCode());
 		}
 		else {
 			assertNull(taskExecution.getEndTime());
+			assertNull(taskExecution.getExitCode());
 		}
 
 		assertEquals("testTask", taskExecution.getTaskName());

--- a/spring-cloud-task-docs/src/main/asciidoc/features.adoc
+++ b/spring-cloud-task-docs/src/main/asciidoc/features.adoc
@@ -98,6 +98,10 @@ map uncaught exceptions to exit codes.  This allows you to be able to indicate a
 level what went wrong.  Also, by mapping exit codes in this manor, Spring Cloud Task will
 record the exit code returned.
 
+NOTE: While the task is running the exit code will be stored as a null in the repository.
+Once complete the appropriate exit code will be stored based on the guidelines enumerated
+above.
+
 [[features-configuration]]
 == Configuration
 


### PR DESCRIPTION
TaskLifecycleListener will set a TaskExecution's exitCode to null upon taskStart in the repository.
Only at the end of the execution will it store the exitCode.

resolves spring-cloud/spring-cloud-task#82