### PR TITLE
Remove hard dependency on SLF4J

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
@@ -24,8 +24,8 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
@@ -63,7 +63,7 @@ public class TaskLifecycleListener implements ApplicationListener<ApplicationEve
 	@Autowired(required = false)
 	private Collection<TaskExecutionListener> taskExecutionListeners;
 
-	private final static Logger logger = LoggerFactory.getLogger(TaskLifecycleListener.class);
+	private final static Log logger = LogFactory.getLog(TaskLifecycleListener.class);
 
 	private final TaskRepository taskRepository;
 

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/TaskListenerExecutorFactory.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/TaskListenerExecutorFactory.java
@@ -24,8 +24,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.aop.framework.autoproxy.AutoProxyUtils;
 import org.springframework.aop.scope.ScopedObject;
 import org.springframework.aop.scope.ScopedProxyUtils;
@@ -41,7 +42,7 @@ import org.springframework.core.annotation.AnnotationUtils;
  */
 public class TaskListenerExecutorFactory implements FactoryBean<TaskListenerExecutor> {
 
-	private final static Logger logger = LoggerFactory.getLogger(TaskListenerExecutor.class);
+	private final static Log logger = LogFactory.getLog(TaskListenerExecutor.class);
 
 	private final Set<Class<?>> nonAnnotatedClasses =
 			Collections.newSetFromMap(new ConcurrentHashMap<Class<?>, Boolean>());

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskRepository.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskRepository.java
@@ -19,8 +19,8 @@ package org.springframework.cloud.task.repository.support;
 import java.util.Date;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.cloud.task.repository.TaskExecution;
@@ -37,7 +37,7 @@ public class SimpleTaskRepository implements TaskRepository {
 	public static final int MAX_EXIT_MESSAGE_SIZE = 2500;
 	public static final int MAX_TASK_NAME_SIZE = 100;
 
-	private final static Logger logger = LoggerFactory.getLogger(SimpleTaskRepository.class);
+	private final static Log logger = LogFactory.getLog(SimpleTaskRepository.class);
 
 	private TaskExecutionDao taskExecutionDao;
 

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/util/TestVerifierUtils.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/util/TestVerifierUtils.java
@@ -16,15 +16,6 @@
 
 package org.springframework.cloud.task.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -37,7 +28,17 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.cloud.task.repository.TaskExecution;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Offers utils to test the  results produced by the code being tested.

--- a/spring-cloud-task-samples/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TaskApplication.java
+++ b/spring-cloud-task-samples/timestamp/src/main/java/org/springframework/cloud/task/timestamp/TaskApplication.java
@@ -21,7 +21,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
@@ -52,7 +53,7 @@ public class TaskApplication {
 	 * A commandline runner that prints a timestamp.
 	 */
 	public class TimestampTask implements CommandLineRunner {
-		private final org.slf4j.Logger logger = LoggerFactory.getLogger(TimestampTask.class);
+		private final Log logger = LogFactory.getLog(TimestampTask.class);
 
 		@Autowired
 		private TimestampTaskProperties config;


### PR DESCRIPTION
This PR removes the use of SLF4J from all non-test code.  SLF4J is still
directly referenced in the unit tests because of the mocking
functionality we're using.  We can explore refactoring that in a later
PR.

Resolves spring-cloud/spring-cloud-task#101