### PR TITLE
Update TaskLifecycleListener to use SmartLifecycle

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/TaskListenerExecutorFactoryBean.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/TaskListenerExecutorFactoryBean.java
@@ -33,6 +33,7 @@ import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.cloud.task.listener.TaskExecutionListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -40,7 +41,7 @@ import org.springframework.core.annotation.AnnotationUtils;
 /**
  * @author Glenn Renfro
  */
-public class TaskListenerExecutorFactory implements FactoryBean<TaskListenerExecutor> {
+public class TaskListenerExecutorFactoryBean implements FactoryBean<TaskExecutionListener> {
 
 	private final static Log logger = LogFactory.getLog(TaskListenerExecutor.class);
 
@@ -55,7 +56,7 @@ public class TaskListenerExecutorFactory implements FactoryBean<TaskListenerExec
 
 	private Map<Method, Object> failedTaskInstances;
 
-	public TaskListenerExecutorFactory(ConfigurableApplicationContext context){
+	public TaskListenerExecutorFactoryBean(ConfigurableApplicationContext context){
 		this.context = context;
 	}
 
@@ -161,5 +162,4 @@ public class TaskListenerExecutorFactory implements FactoryBean<TaskListenerExec
 					});
 		}
 	}
-
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskRepository.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskRepository.java
@@ -59,7 +59,7 @@ public class SimpleTaskRepository implements TaskRepository {
 		validateExitInformation(executionId, exitCode, endTime);
 		exitMessage = trimExitMessage(exitMessage);
 		taskExecutionDao.completeTaskExecution(executionId, exitCode, endTime, exitMessage);
-		logger.info("Updating: TaskExecution with executionId="+executionId
+		logger.debug("Updating: TaskExecution with executionId="+executionId
 				+ " with the following {"
 				+ "exitCode=" + exitCode
 				+ ", endTime=" + endTime
@@ -76,7 +76,7 @@ public class SimpleTaskRepository implements TaskRepository {
 		validateCreateInformation(startTime, taskName);
 		TaskExecution taskExecution =
 				taskExecutionDao.createTaskExecution(taskName, startTime, parameters);
-		logger.info("Creating: " + taskExecution.toString());
+		logger.debug("Creating: " + taskExecution.toString());
 		return taskExecution;
 	}
 

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskRepository.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class SimpleTaskRepository implements TaskRepository {
 		validateExitInformation(executionId, exitCode, endTime);
 		exitMessage = trimExitMessage(exitMessage);
 		taskExecutionDao.completeTaskExecution(executionId, exitCode, endTime, exitMessage);
-		logger.debug("Updating: TaskExecution with executionId="+executionId
+		logger.info("Updating: TaskExecution with executionId="+executionId
 				+ " with the following {"
 				+ "exitCode=" + exitCode
 				+ ", endTime=" + endTime

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/TaskExecutionDaoFactoryBean.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/TaskExecutionDaoFactoryBean.java
@@ -40,8 +40,6 @@ public class TaskExecutionDaoFactoryBean implements FactoryBean<TaskExecutionDao
 
 	private TaskExecutionDao dao = null;
 
-	private String dataSourceName;
-
 	private String tablePrefix = DEFAULT_TABLE_PREFIX;
 
 	/**
@@ -84,17 +82,6 @@ public class TaskExecutionDaoFactoryBean implements FactoryBean<TaskExecutionDao
 	@Override
 	public boolean isSingleton() {
 		return true;
-	}
-
-	/**
-	 * Identifies the {@link DataSource} to be used if one is to be used.  By default, the
-	 * name is not specified and it is assumed that only one DataSource exists within the
-	 * context.
-	 *
-	 * @param dataSourceName bean id for the DataSource to be used.
-	 */
-	public void setDataSourceName(String dataSourceName) {
-		this.dataSourceName = dataSourceName;
 	}
 
 	/**

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/TaskExecutionDaoFactoryBean.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/TaskExecutionDaoFactoryBean.java
@@ -23,10 +23,8 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.cloud.task.repository.dao.JdbcTaskExecutionDao;
 import org.springframework.cloud.task.repository.dao.MapTaskExecutionDao;
 import org.springframework.cloud.task.repository.dao.TaskExecutionDao;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.jdbc.support.MetaDataAccessException;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * A {@link FactoryBean} implementation that creates the appropriate
@@ -38,7 +36,7 @@ public class TaskExecutionDaoFactoryBean implements FactoryBean<TaskExecutionDao
 
 	public static final String DEFAULT_TABLE_PREFIX = "TASK_";
 
-	private ConfigurableApplicationContext context;
+	private DataSource dataSource;
 
 	private TaskExecutionDao dao = null;
 
@@ -54,37 +52,21 @@ public class TaskExecutionDaoFactoryBean implements FactoryBean<TaskExecutionDao
 	}
 
 	/**
-	 * ApplicationContext provided will be used to obtain the appropriate
-	 * {@link DataSource}.
+	 * {@link DataSource} to be used.
 	 *
-	 * @param context context for this application
+	 * @param dataSource {@link DataSource} to be used.
 	 */
-	public TaskExecutionDaoFactoryBean(ConfigurableApplicationContext context) {
-		Assert.notNull(context, "An ApplicationContext is required");
+	public TaskExecutionDaoFactoryBean(DataSource dataSource) {
+		Assert.notNull(dataSource, "A DataSource is required");
 
-		this.context = context;
+		this.dataSource = dataSource;
 	}
 
 	@Override
 	public TaskExecutionDao getObject() throws Exception {
 		if(this.dao == null) {
-			if(this.context != null) {
-				if (StringUtils.hasText(this.dataSourceName)) {
-					if(!this.context.containsBean(this.dataSourceName)) {
-						throw new IllegalArgumentException("The configured dataSourceName is not available in the current context");
-					}
-
-					DataSource dataSource = (DataSource) this.context.getBean(this.dataSourceName);
-					buildTaskExecutionDao(dataSource);
-				}
-				else if (this.context.getBeanNamesForType(DataSource.class).length == 1) {
-					DataSource dataSource = this.context.getBean(DataSource.class);
-					buildTaskExecutionDao(dataSource);
-
-				}
-				else {
-					this.dao = new MapTaskExecutionDao();
-				}
+			if (this.dataSource != null) {
+				buildTaskExecutionDao(this.dataSource);
 			}
 			else {
 				this.dao = new MapTaskExecutionDao();

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/configuration/TestConfiguration.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/configuration/TestConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.cloud.task.repository.support.SimpleTaskExplorer;
 import org.springframework.cloud.task.repository.support.SimpleTaskRepository;
 import org.springframework.cloud.task.repository.support.TaskExecutionDaoFactoryBean;
 import org.springframework.cloud.task.repository.support.TaskRepositoryInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
@@ -45,9 +44,6 @@ public class TestConfiguration implements InitializingBean {
 
 	@Autowired(required = false)
 	private ResourceLoader resourceLoader;
-
-	@Autowired
-	private ConfigurableApplicationContext applicationContext;
 
 	private TaskExecutionDaoFactoryBean taskExecutionDaoFactoryBean;
 
@@ -83,6 +79,11 @@ public class TestConfiguration implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		this.taskExecutionDaoFactoryBean = new TaskExecutionDaoFactoryBean(this.applicationContext);
+		if(this.dataSource != null) {
+			this.taskExecutionDaoFactoryBean = new TaskExecutionDaoFactoryBean(this.dataSource);
+		}
+		else {
+			this.taskExecutionDaoFactoryBean = new TaskExecutionDaoFactoryBean();
+		}
 	}
 }

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskExecutionListenerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskExecutionListenerTests.java
@@ -16,24 +16,19 @@
 
 package org.springframework.cloud.task.listener;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.Date;
 
 import org.junit.After;
 import org.junit.Test;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.event.ApplicationFailedEvent;
 import org.springframework.cloud.task.listener.annotation.AfterTask;
 import org.springframework.cloud.task.listener.annotation.BeforeTask;
 import org.springframework.cloud.task.listener.annotation.FailedTask;
-import org.springframework.cloud.task.listener.annotation.TaskListenerExecutor;
-import org.springframework.cloud.task.listener.annotation.TaskListenerExecutorFactory;
+import org.springframework.cloud.task.listener.annotation.TaskListenerExecutorFactoryBean;
 import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.cloud.task.util.TestDefaultConfiguration;
 import org.springframework.cloud.task.util.TestListener;
@@ -42,6 +37,11 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ContextClosedEvent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Verifies that the TaskExecutionListener invocations occur at the appropriate task
@@ -203,10 +203,9 @@ public class TaskExecutionListenerTests {
 		}
 
 		@Bean
-		public TaskListenerExecutor taskListenerExecutor(ConfigurableApplicationContext context) throws Exception
+		public TaskListenerExecutorFactoryBean taskListenerExecutor(ConfigurableApplicationContext context) throws Exception
 		{
-			TaskListenerExecutorFactory taskListenerExecutorFactory = new TaskListenerExecutorFactory(context);
-			return taskListenerExecutorFactory.getObject();
+			return new TaskListenerExecutorFactoryBean(context);
 		}
 
 		public static class AnnotatedTaskListener extends TestListener {

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskRepositoryMapTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskRepositoryMapTests.java
@@ -27,9 +27,6 @@ import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.cloud.task.repository.dao.MapTaskExecutionDao;
 import org.springframework.cloud.task.util.TaskExecutionCreator;
 import org.springframework.cloud.task.util.TestVerifierUtils;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Configuration;
 
 import static org.springframework.test.util.AssertionErrors.assertTrue;
 
@@ -43,8 +40,7 @@ public class SimpleTaskRepositoryMapTests {
 
 	@Before
 	public void setUp() {
-		ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(EmptyConfiguration.class);
-		this.taskRepository = new SimpleTaskRepository(new TaskExecutionDaoFactoryBean(context));
+		this.taskRepository = new SimpleTaskRepository(new TaskExecutionDaoFactoryBean());
 	}
 
 	@Test
@@ -52,8 +48,7 @@ public class SimpleTaskRepositoryMapTests {
 		TaskExecution expectedTaskExecution =
 				TaskExecutionCreator.createAndStoreTaskExecutionNoParams(taskRepository);
 		TestVerifierUtils.verifyTaskExecution(expectedTaskExecution,
-				getSingleTaskExecutionFromMapRepository(taskRepository,
-						expectedTaskExecution.getExecutionId()));
+				getSingleTaskExecutionFromMapRepository(expectedTaskExecution.getExecutionId()));
 	}
 
 	@Test
@@ -61,8 +56,7 @@ public class SimpleTaskRepositoryMapTests {
 		TaskExecution expectedTaskExecution =
 				TaskExecutionCreator.createAndStoreTaskExecutionWithParams(taskRepository);
 		TestVerifierUtils.verifyTaskExecution(expectedTaskExecution,
-				getSingleTaskExecutionFromMapRepository(taskRepository,
-						expectedTaskExecution.getExecutionId()));
+				getSingleTaskExecutionFromMapRepository(expectedTaskExecution.getExecutionId()));
 	}
 
 	@Test
@@ -75,8 +69,7 @@ public class SimpleTaskRepositoryMapTests {
 		TestVerifierUtils.verifyTaskExecution(expectedTaskExecution, actualTaskExecution);
 	}
 
-	private TaskExecution getSingleTaskExecutionFromMapRepository(
-			TaskRepository repository, long taskExecutionId){
+	private TaskExecution getSingleTaskExecutionFromMapRepository(long taskExecutionId){
 		Map<Long, TaskExecution> taskMap = ((MapTaskExecutionDao)
 				((SimpleTaskRepository)taskRepository).getTaskExecutionDao()).getTaskExecutions();
 		assertTrue("taskExecutionId must be in MapTaskExecutionRepository",
@@ -91,7 +84,4 @@ public class SimpleTaskRepositoryMapTests {
 		expectedTaskExecution.setExitCode(-1);
 		TaskExecutionCreator.completeExecution(taskRepository, expectedTaskExecution);
 	}
-
-	@Configuration
-	public static class EmptyConfiguration{}
 }

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/TaskDatabaseInitializerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/TaskDatabaseInitializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,6 @@
  */
 
 package org.springframework.cloud.task.repository.support;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
 
 import javax.sql.DataSource;
 
@@ -37,6 +32,11 @@ import org.springframework.cloud.task.repository.dao.MapTaskExecutionDao;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Verifies that task initialization occurs properly.
@@ -70,7 +70,7 @@ public class TaskDatabaseInitializerTests {
 	@Test
 	public void testNoDatabase() throws Exception {
 		this.context = new AnnotationConfigApplicationContext(EmptyConfiguration.class);
-		SimpleTaskRepository repository = new SimpleTaskRepository(new TaskExecutionDaoFactoryBean(this.context));
+		SimpleTaskRepository repository = new SimpleTaskRepository(new TaskExecutionDaoFactoryBean());
 		assertThat(repository.getTaskExecutionDao(), instanceOf(MapTaskExecutionDao.class));
 		MapTaskExecutionDao dao = (MapTaskExecutionDao) repository.getTaskExecutionDao();
 		assertEquals(0, dao.getTaskExecutions().size());

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/util/TestDefaultConfiguration.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/util/TestDefaultConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.cloud.task.util;
+
+import javax.sql.DataSource;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
  * Initializes the beans needed to test default task behavior.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  */
 @Configuration
 public class TestDefaultConfiguration implements InitializingBean {
@@ -72,6 +75,12 @@ public class TestDefaultConfiguration implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		this.factoryBean = new TaskExecutionDaoFactoryBean(this.context);
+		if(this.context.getBeanNamesForType(DataSource.class).length == 1){
+			DataSource dataSource = this.context.getBean(DataSource.class);
+			this.factoryBean = new TaskExecutionDaoFactoryBean(dataSource);
+		}
+		else {
+			this.factoryBean = new TaskExecutionDaoFactoryBean();
+		}
 	}
 }

--- a/spring-cloud-task-docs/src/main/asciidoc/features.adoc
+++ b/spring-cloud-task-docs/src/main/asciidoc/features.adoc
@@ -33,13 +33,10 @@ Spring Boot application configured to be a task (annotated with the `@EnableTask
 annotation).
 
 At the beginning of a task, an entry in the `TaskRepository` is created recording the
-start event.  This event is triggered via the `ContextRefreshEvent` being triggered by
-Spring Framework.
+start event.  This event is triggered via `SmartLifecycle#start` being triggered by
+Spring Framework.  This indicates to the system that all beans are ready for use and is
+before the execution of any of the `*Runner`s provided by Spring Boot.
 
-NOTE: As Spring Cloud Task is expected to consist of a single application context.  If
-multiple application contexts are used (parent/child relationships for example), the first
-`ContextRefreshEvent` that is published by Spring will be recorded as the start of the
-task.
 
 NOTE: The recording of a task will only occur upon the successful bootstrapping of an
 `ApplicationContext`.  If the context fails to bootstrap at all, the task's execution will
@@ -70,7 +67,7 @@ assumed to be 0.
 |The name for the task as determined by the configured `TaskNameResolver`.
 
 |`starTime`
-|The time the task was started as indicated by the `ContextRefreshEvent`.
+|The time the task was started as indicated by the `SmartLifecycle#start` call.
 
 |`endTime`
 |The time the task was completed as indicated by the `ContextClosedEvent`.


### PR DESCRIPTION
This commit changes the starting point of a task from the point when the
ApplicationContext issues the ContextRefreshedEvent to
SmartLifecycle#start.  This is a more accurate point of start for a task
in that all beans should now be available.  It also allows us to clean
up many ApplicationContext hacks that were present to get around the
fact that many beans were not ready when a Task was attempting to begin.

Resolves spring-cloud/spring-cloud-task#107