### PR TITLE
Remove binder dependency from spring-cloud-task-stream

### DIFF
--- a/spring-cloud-task-stream/pom.xml
+++ b/spring-cloud-task-stream/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>spring-cloud-task-stream</artifactId>
 	<packaging>jar</packaging>
 	<name>Spring Cloud Task Stream </name>
-	<description>Allows Tasks to be a part of a stream</description>
+	<description>Allows a Task to be a part of a stream</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -28,21 +28,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-redis</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-test</artifactId>
-			<version>4.2.2.RELEASE</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-task-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
@@ -56,11 +41,6 @@
 			<artifactId>spring-cloud-stream-test-support</artifactId>
 			<version>1.0.0.BUILD-SNAPSHOT</version>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-redis</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
- Spring Cloud Task Stream shouldn't depend on a specific binder implementation; hence removing redis binder from dependencies
   - The binder dependency needs to come from the task application
 - Also removed few other unwanted dependencies

This resolves #120