### PR TITLE
Replaces Redis as sample binder with Rabbit (Do Not Merge)

### DIFF
--- a/spring-cloud-task-batch/pom.xml
+++ b/spring-cloud-task-batch/pom.xml
@@ -24,13 +24,11 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-spi</artifactId>
-			<version>1.0.0.M1</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-local</artifactId>
-			<version>1.0.0.M1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-task-dependencies/pom.xml
+++ b/spring-cloud-task-dependencies/pom.xml
@@ -15,17 +15,66 @@
         <relativePath/>
 	</parent>
 
+	<properties>
+		<spring-cloud-task.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-task.version>
+		<spring-cloud-stream.version>1.0.0.RC3</spring-cloud-stream.version>
+		<spring-cloud-deployer-spi.version>1.0.0.M1</spring-cloud-deployer-spi.version>
+		<spring-cloud-deployer-local.version>1.0.0.M1</spring-cloud-deployer-local.version>
+		<spring-cloud-stream-binder-redis.version>1.0.0.RC2</spring-cloud-stream-binder-redis.version>
+	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-task-core</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${spring-cloud-task.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-task-batch</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>${spring-cloud-task.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-task-stream</artifactId>
+				<version>${spring-cloud-task.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream</artifactId>
+				<version>${spring-cloud-stream.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream-test-support-internal</artifactId>
+				<version>${spring-cloud-stream.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream-test-support</artifactId>
+				<version>${spring-cloud-stream.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-deployer-spi</artifactId>
+				<version>${spring-cloud-deployer-spi.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-deployer-local</artifactId>
+				<version>${spring-cloud-deployer-local.version}</version>
+				<optional>true</optional>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-deployer-local</artifactId>
+				<version>${spring-cloud-deployer-spi.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-stream-binder-redis</artifactId>
+				<version>${spring-cloud-stream-binder-redis.version}</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-task-dependencies/pom.xml
+++ b/spring-cloud-task-dependencies/pom.xml
@@ -20,7 +20,7 @@
 		<spring-cloud-stream.version>1.0.0.RC3</spring-cloud-stream.version>
 		<spring-cloud-deployer-spi.version>1.0.0.M1</spring-cloud-deployer-spi.version>
 		<spring-cloud-deployer-local.version>1.0.0.M1</spring-cloud-deployer-local.version>
-		<spring-cloud-stream-binder-redis.version>1.0.0.RC2</spring-cloud-stream-binder-redis.version>
+		<spring-cloud-stream-binder-rabbit.version>1.0.0.RC3</spring-cloud-stream-binder-rabbit.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -72,8 +72,8 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-stream-binder-redis</artifactId>
-				<version>${spring-cloud-stream-binder-redis.version}</version>
+				<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+				<version>${spring-cloud-stream-binder-rabbit.version}</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>

--- a/spring-cloud-task-integration-tests/pom.xml
+++ b/spring-cloud-task-integration-tests/pom.xml
@@ -30,7 +30,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-redis</artifactId>
+			<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-task-integration-tests/pom.xml
+++ b/spring-cloud-task-integration-tests/pom.xml
@@ -16,7 +16,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-stream</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -27,13 +26,11 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-			<version>1.0.0.RC3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-redis</artifactId>
-			<version>1.0.0.RC2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/listener/BatchExecutionEventTests.java
+++ b/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/listener/BatchExecutionEventTests.java
@@ -32,9 +32,9 @@ import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
-import org.springframework.cloud.stream.binder.redis.config.RedisServiceAutoConfiguration;
+import org.springframework.cloud.stream.binder.rabbit.config.RabbitServiceAutoConfiguration;
 import org.springframework.cloud.stream.messaging.Sink;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.stream.test.junit.rabbit.RabbitTestSupport;
 import org.springframework.cloud.task.batch.configuration.TaskBatchAutoConfiguration;
 import org.springframework.cloud.task.batch.listener.BatchEventAutoConfiguration;
 import org.springframework.cloud.task.batch.listener.support.JobExecutionEvent;
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class BatchExecutionEventTests {
 	@ClassRule
-	public static RedisTestSupport redisTestSupport = new RedisTestSupport();
+	public static RabbitTestSupport rabbitTestSupport = new RabbitTestSupport();
 
 	// Count for two job execution events per job
 	static CountDownLatch jobExecutionLatch = new CountDownLatch(2);
@@ -94,7 +94,7 @@ public class BatchExecutionEventTests {
 	public void testContext() {
 		applicationContext = new SpringApplicationBuilder()
 				.sources(this.getConfigurations(BatchExecutionEventTests.ListenerBinding.class, JobConfiguration.class))
-				.build().run(new String[]{ "--spring.cloud.task.closecontext.enable=false" });
+				.build().run(getCommandLineParams("--spring.cloud.stream.bindings.job-execution-events.destination=bazbar"));
 
 		assertNotNull(applicationContext.getBean("jobExecutionEventsListener"));
 		assertNotNull(applicationContext.getBean("stepExecutionEventsListener"));
@@ -258,7 +258,7 @@ public class BatchExecutionEventTests {
 				TaskBatchAutoConfiguration.class,
 				TaskEventAutoConfiguration.class,
 				BatchEventAutoConfiguration.class,
-				RedisServiceAutoConfiguration.class,
+				RabbitServiceAutoConfiguration.class,
 				sinkClazz };
 	}
 
@@ -266,7 +266,7 @@ public class BatchExecutionEventTests {
 		return new String[]{ "--spring.cloud.task.closecontext.enable=false",
 				"--spring.cloud.task.name=" + TASK_NAME,
 				"--spring.main.web-environment=false",
-				"--spring.cloud.stream.defaultBinder=redis",
+				"--spring.cloud.stream.defaultBinder=rabbit",
 				"--spring.cloud.stream.bindings.task-events.destination=test",
 				sinkChannelParam };
 	}

--- a/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/listener/TaskEventTests.java
+++ b/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/listener/TaskEventTests.java
@@ -31,16 +31,14 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
-import org.springframework.cloud.stream.binder.redis.config.RedisServiceAutoConfiguration;
+import org.springframework.cloud.stream.binder.rabbit.config.RabbitServiceAutoConfiguration;
 import org.springframework.cloud.stream.messaging.Sink;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.stream.test.junit.rabbit.RabbitTestSupport;
 import org.springframework.cloud.task.configuration.EnableTask;
 import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
@@ -52,7 +50,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class TaskEventTests {
 
 	@ClassRule
-	public static RedisTestSupport redisTestSupport = new RedisTestSupport();
+	public static RabbitTestSupport rabbitTestSupport = new RabbitTestSupport();
 
 	// Count for two task execution events per task
 	static CountDownLatch latch = new CountDownLatch(2);
@@ -64,10 +62,10 @@ public class TaskEventTests {
 		ConfigurableApplicationContext applicationContext = new SpringApplicationBuilder().sources(new Object[] {TaskEventsConfiguration.class,
 				TaskEventAutoConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class,
-				RedisServiceAutoConfiguration.class}).build().run(new String[] {"--spring.cloud.task.closecontext.enable=false",
+				RabbitServiceAutoConfiguration.class}).build().run(new String[] {"--spring.cloud.task.closecontext.enable=false",
 				"--spring.cloud.task.name=" + TASK_NAME,
 				"--spring.main.web-environment=false",
-				"--spring.cloud.stream.defaultBinder=redis",
+				"--spring.cloud.stream.defaultBinder=rabbit",
 				"--spring.cloud.stream.bindings.task-events.destination=test"});
 		assertNotNull(applicationContext.getBean("taskEventListener"));
 		assertNotNull(applicationContext.getBean(TaskEventAutoConfiguration.TaskEventChannels.class));
@@ -88,11 +86,6 @@ public class TaskEventTests {
 		public void receive(TaskExecution execution) {
 			assertTrue(String.format("Task name should be '%s'", TASK_NAME), execution.getTaskName().equals(TASK_NAME));
 			latch.countDown();
-		}
-
-		@Bean
-		public RedisConnectionFactory redisConnectionFactory() {
-			return redisTestSupport.getResource();
 		}
 	}
 }

--- a/spring-cloud-task-samples/batch-events/pom.xml
+++ b/spring-cloud-task-samples/batch-events/pom.xml
@@ -12,10 +12,9 @@
 	<description>Sample of sending batch events via Spring Cloud Streams</description>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.3.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-task-samples</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -27,12 +26,10 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-core</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-stream</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -50,12 +47,11 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-redis</artifactId>
-			<version>1.0.0.RC2</version>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-			<version>1.0.0.RC3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-task-samples/batch-events/pom.xml
+++ b/spring-cloud-task-samples/batch-events/pom.xml
@@ -46,7 +46,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-redis</artifactId>
+			<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-task-samples/batch-events/src/test/java/io/spring/cloud/BatchEventsApplicationTests.java
+++ b/spring-cloud-task-samples/batch-events/src/test/java/io/spring/cloud/BatchEventsApplicationTests.java
@@ -30,14 +30,14 @@ import org.springframework.boot.test.OutputCapture;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.messaging.Sink;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.stream.test.junit.rabbit.RabbitTestSupport;
 import org.springframework.cloud.task.batch.listener.support.JobExecutionEvent;
 import org.springframework.context.annotation.PropertySource;
 
 public class BatchEventsApplicationTests {
 
 	@ClassRule
-	public static RedisTestSupport redisTestSupport = new RedisTestSupport();
+	public static RabbitTestSupport rabbitTestSupport = new RabbitTestSupport();
 
 	@Rule
 	public OutputCapture outputCapture = new OutputCapture();

--- a/spring-cloud-task-samples/batch-job/pom.xml
+++ b/spring-cloud-task-samples/batch-job/pom.xml
@@ -12,9 +12,9 @@
 	<name>Batch Job Sample Application</name>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.3.RELEASE</version>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-task-samples</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -30,12 +30,10 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-core</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-batch</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/spring-cloud-task-samples/partitioned-batch-job/pom.xml
+++ b/spring-cloud-task-samples/partitioned-batch-job/pom.xml
@@ -11,9 +11,9 @@
 	<description>Sample of using the DeployerPartitionHandler</description>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.3.RELEASE</version>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-task-samples</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -30,7 +30,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-batch</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -41,7 +40,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-local</artifactId>
-			<version>1.0.0.M1</version>
 		</dependency>
 
 		<dependency>

--- a/spring-cloud-task-samples/pom.xml
+++ b/spring-cloud-task-samples/pom.xml
@@ -31,6 +31,18 @@
 		<module>batch-events</module>
 	</modules>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-task-dependencies</artifactId>
+				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<build>
 		<pluginManagement>
 			<plugins>

--- a/spring-cloud-task-samples/task-events/README.adoc
+++ b/spring-cloud-task-samples/task-events/README.adoc
@@ -30,4 +30,4 @@ $ java -jar <PATH_TO_LOG_SINK_JAR>/log-sink-1.0.0.BUILD-SNAPSHOT-exec.jar --serv
 
 == Dependencies:
 
-The task processor requires an instance of Redis to be running.
+The task processor requires an instance of RabbitMQ to be running.

--- a/spring-cloud-task-samples/task-events/pom.xml
+++ b/spring-cloud-task-samples/task-events/pom.xml
@@ -39,13 +39,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-redis</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-redis</artifactId>
+			<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		

--- a/spring-cloud-task-samples/task-events/pom.xml
+++ b/spring-cloud-task-samples/task-events/pom.xml
@@ -12,10 +12,9 @@
 	<description>Demo of publishing task events to Spring Cloud Streams</description>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.3.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-task-samples</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -32,13 +31,11 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-core</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-stream</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -49,7 +46,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-redis</artifactId>
-			<version>1.0.0.RC2</version>
+			<scope>compile</scope>
 		</dependency>
 		
 		<dependency>

--- a/spring-cloud-task-samples/taskprocessor/README.adoc
+++ b/spring-cloud-task-samples/taskprocessor/README.adoc
@@ -39,4 +39,4 @@ $ ./mvnw clean install
 
 == Dependencies:
 
-The task processor requires an instance of Redis to be running.
+The task processor requires an instance of RabbitMQ to be running.

--- a/spring-cloud-task-samples/taskprocessor/pom.xml
+++ b/spring-cloud-task-samples/taskprocessor/pom.xml
@@ -38,12 +38,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-redis</artifactId>
+			<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
 			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-redis</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-task-samples/taskprocessor/pom.xml
+++ b/spring-cloud-task-samples/taskprocessor/pom.xml
@@ -12,10 +12,9 @@
 	<description>Task processor sample application</description>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.3.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-task-samples</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -32,17 +31,15 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-stream</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream</artifactId>
-			<version>1.0.0.RC3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-redis</artifactId>
-			<version>1.0.0.RC2</version>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -56,7 +53,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support</artifactId>
-			<version>1.0.0.RC3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-task-samples/tasksink/README.adoc
+++ b/spring-cloud-task-samples/tasksink/README.adoc
@@ -16,4 +16,4 @@ $ ./mvnw clean install
 
 == Dependencies:
 
-The task processor requires an instance of Redis to be running.
+The task processor requires an instance of RabbitMQ to be running.

--- a/spring-cloud-task-samples/tasksink/pom.xml
+++ b/spring-cloud-task-samples/tasksink/pom.xml
@@ -37,14 +37,9 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-redis</artifactId>
+			<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
 			<scope>compile</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-redis</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support</artifactId>

--- a/spring-cloud-task-samples/tasksink/pom.xml
+++ b/spring-cloud-task-samples/tasksink/pom.xml
@@ -12,10 +12,9 @@
 	<description>Task sink sample project</description>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.3.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-task-samples</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -31,17 +30,15 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-local</artifactId>
-			<version>1.0.0.M1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-stream</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-redis</artifactId>
-			<version>1.0.0.RC2</version>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -51,7 +48,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support</artifactId>
-			<version>1.0.0.RC3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-task-samples/timestamp/pom.xml
+++ b/spring-cloud-task-samples/timestamp/pom.xml
@@ -13,9 +13,9 @@
 	<description>Spring Cloud Timestamp Task</description>
 
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.3.3.RELEASE</version>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-task-samples</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -36,7 +36,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-core</artifactId>
-			<version>1.0.0.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-task-stream/pom.xml
+++ b/spring-cloud-task-stream/pom.xml
@@ -49,12 +49,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-redis</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-redis</artifactId>
+			<artifactId>spring-cloud-starter-stream-rabbit</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-task-stream/pom.xml
+++ b/spring-cloud-task-stream/pom.xml
@@ -22,12 +22,10 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream</artifactId>
-			<version>1.0.0.RC3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-deployer-local</artifactId>
-			<version>1.0.0.M1</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -47,13 +45,11 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support-internal</artifactId>
-			<version>1.0.0.RC3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-redis</artifactId>
-			<version>1.0.0.RC2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-task-stream/src/test/java/org/springframework/cloud/task/launcher/TaskLauncherSinkTests.java
+++ b/spring-cloud-task-stream/src/test/java/org/springframework/cloud/task/launcher/TaskLauncherSinkTests.java
@@ -28,7 +28,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.deployer.spi.task.LaunchState;
 import org.springframework.cloud.stream.annotation.Bindings;
 import org.springframework.cloud.stream.messaging.Sink;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.stream.test.junit.rabbit.RabbitTestSupport;
 import org.springframework.cloud.task.launcher.configuration.TaskConfiguration;
 import org.springframework.cloud.task.launcher.util.TaskLauncherSinkApplication;
 import org.springframework.context.ApplicationContext;
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 public class TaskLauncherSinkTests {
 
 	@ClassRule
-	public static RedisTestSupport redisTestSupport = new RedisTestSupport();
+	public static RabbitTestSupport rabbitTestSupport = new RabbitTestSupport();
 
 	private final static String DEFAULT_STATUS = "test_status";
 

--- a/spring-cloud-task-stream/src/test/java/org/springframework/cloud/task/listener/TaskEventTests.java
+++ b/spring-cloud-task-stream/src/test/java/org/springframework/cloud/task/listener/TaskEventTests.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
-import org.springframework.cloud.stream.test.junit.redis.RedisTestSupport;
+import org.springframework.cloud.stream.test.junit.rabbit.RabbitTestSupport;
 import org.springframework.cloud.task.configuration.EnableTask;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertNotNull;
 public class TaskEventTests {
 
 	@Rule
-	public RedisTestSupport redisTestSupport = new RedisTestSupport();
+	public RabbitTestSupport rabbitTestSupport = new RabbitTestSupport();
 
 	private static final String TASK_NAME = "taskEventTest";
 


### PR DESCRIPTION
SCT-132 needs to be merged in first.

In short had a conversation with Marius and they have deprecated the Redis Binder.  
resolves spring-cloud/spring-cloud-task#134
