### PR TITLE
Fix NPE when return an eventExitCode before ApplicationFailedEvent

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
@@ -125,7 +125,6 @@ public class TaskLifecycleListener implements ApplicationListener<ApplicationEve
 		}
 		else if(applicationEvent instanceof ExitCodeEvent){
 			this.exitCodeEvent = (ExitCodeEvent) applicationEvent;
-			doTaskEnd();
 		}
 		else if(applicationEvent instanceof ApplicationReadyEvent) {
 			doTaskEnd();
@@ -159,7 +158,7 @@ public class TaskLifecycleListener implements ApplicationListener<ApplicationEve
 				this.taskExecution.setExitMessage(stackTraceToString(this.applicationFailedEvent.getException()));
 			}
 
-			if(this.taskExecution.getExitCode() != 0){
+			if (this.applicationFailedEvent != null && this.taskExecution.getExitCode() != 0) {
 				taskExecution.setExitMessage(invokeOnTaskError(taskExecution,
 						this.applicationFailedEvent.getException()).getExitMessage());
 			}

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskLifecycleListenerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskLifecycleListenerTests.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ExitCodeEvent;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.event.ApplicationFailedEvent;
@@ -109,6 +110,20 @@ public class TaskLifecycleListenerTests {
 		context.publishEvent(new ApplicationReadyEvent(application, new String[0], context));
 
 		verifyTaskExecution(0, true, 1, exception);
+	}
+
+	@Test
+	public void testTaskFailedWithExitCodeEvent() {
+		final int exitCode = 10;
+		context.refresh();
+		RuntimeException exception = new RuntimeException("This was expected");
+		SpringApplication application = new SpringApplication();
+		this.taskExplorer = context.getBean(TaskExplorer.class);
+		context.publishEvent(new ExitCodeEvent(context, exitCode));
+		context.publishEvent(new ApplicationFailedEvent(application, new String[0], context, exception));
+		context.publishEvent(new ApplicationReadyEvent(application, new String[0], context));
+
+		verifyTaskExecution(0, true, exitCode, exception);
 	}
 
 	@Test


### PR DESCRIPTION
**Problem:**

NPE when an eventExitCode is fired before ApplicationFailedEvent.

**Example:**

```
public class HelloCommandListRunner implements CommandLineRunner, ExitCodeExceptionMapper {

    @Override
    public void run(String... args) throws Exception {
        throw new ExceptionTest("test");
    }

    @Override
    public int getExitCode(Throwable exception) {

        if (exception.getCause() instanceof ExceptionTest) {
            return 10;
        }

        return 0;
    }
}

```

This causes a NPE because the error code is different from 0 but _this.applicationFailedEvent_ is not set.

```
if(this.taskExecution.getExitCode() != 0){
				taskExecution.setExitMessage(invokeOnTaskError(taskExecution,
						this.applicationFailedEvent.getException()).getExitMessage());
			}

```

I also remove the _doTaskEnd();_ for _ExitCodeEvent_ because every time we sent an ExitCodeEvent we also send an _ApplicationFailedEvent_, so the second one will end the task, otherwise the information from the last event (_ApplicationFailedEvent_) will be never recorded.