### PR TITLE
Refactored for CloudFoundry Support

### DIFF
--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/CommandLineArgsProvider.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/CommandLineArgsProvider.java
@@ -15,29 +15,28 @@
  */
 package org.springframework.cloud.task.batch.partition;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 import org.springframework.batch.item.ExecutionContext;
 
 /**
- * A simple no-op implementation of the {@link EnvironmentVariablesProvider}.  It returns
- * an empty {@link Map}.
+ * Strategy to allow for the customization of command line arguments passed to each
+ * partition's execution.
  *
  * @author Michael Minella
- *
- * @since 1.0.2
+ * @since 1.1.0
  */
-public class NoOpEnvironmentVariablesProvider implements EnvironmentVariablesProvider {
+public interface CommandLineArgsProvider {
 
 	/**
+	 * Returns a unique list of command line arguements to be passed to the partition's
+	 * worker for the specified {@link ExecutionContext}.
 	 *
-	 * @param executionContext the {@link ExecutionContext} associated with the worker's
-	 * 			step
-	 * @return an empty {@link Map}
+	 * Note: This method is called once per partition.
+	 *
+	 * @param executionContext the unique state for the step to be executed
+	 * @return a list of formatted command line arguments to be passed to the worker (the
+	 *         list will be joined via spaces).
 	 */
-	@Override
-	public Map<String, String> getEnvironmentVariables(ExecutionContext executionContext) {
-		return Collections.emptyMap();
-	}
+	List<String> getCommandLineArgs(ExecutionContext executionContext);
 }

--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/PassThroughCommandLineArgsProvider.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/PassThroughCommandLineArgsProvider.java
@@ -15,29 +15,29 @@
  */
 package org.springframework.cloud.task.batch.partition;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 import org.springframework.batch.item.ExecutionContext;
+import org.springframework.util.Assert;
 
 /**
- * A simple no-op implementation of the {@link EnvironmentVariablesProvider}.  It returns
- * an empty {@link Map}.
+ * Returns the {@code List<String>} provided.
  *
  * @author Michael Minella
- *
- * @since 1.0.2
+ * @since 1.1.0
  */
-public class NoOpEnvironmentVariablesProvider implements EnvironmentVariablesProvider {
+public class PassThroughCommandLineArgsProvider implements CommandLineArgsProvider {
 
-	/**
-	 *
-	 * @param executionContext the {@link ExecutionContext} associated with the worker's
-	 * 			step
-	 * @return an empty {@link Map}
-	 */
+	private final List<String> commandLineArgs;
+
+	public PassThroughCommandLineArgsProvider(List<String> commandLineArgs) {
+		Assert.notNull(commandLineArgs, "commandLinerArgs is required");
+
+		this.commandLineArgs = commandLineArgs;
+	}
+
 	@Override
-	public Map<String, String> getEnvironmentVariables(ExecutionContext executionContext) {
-		return Collections.emptyMap();
+	public List<String> getCommandLineArgs(ExecutionContext executionContext) {
+		return commandLineArgs;
 	}
 }

--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/SimpleCommandLineArgsProvider.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/SimpleCommandLineArgsProvider.java
@@ -15,29 +15,30 @@
  */
 package org.springframework.cloud.task.batch.partition;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 import org.springframework.batch.item.ExecutionContext;
+import org.springframework.cloud.task.repository.TaskExecution;
+import org.springframework.util.Assert;
 
 /**
- * A simple no-op implementation of the {@link EnvironmentVariablesProvider}.  It returns
- * an empty {@link Map}.
+ * Returns any command line arguments used with the {@link TaskExecution} provided.
  *
  * @author Michael Minella
- *
- * @since 1.0.2
+ * @since 1.1.0
  */
-public class NoOpEnvironmentVariablesProvider implements EnvironmentVariablesProvider {
+public class SimpleCommandLineArgsProvider implements CommandLineArgsProvider {
 
-	/**
-	 *
-	 * @param executionContext the {@link ExecutionContext} associated with the worker's
-	 * 			step
-	 * @return an empty {@link Map}
-	 */
+	private final TaskExecution taskExecution;
+
+	public SimpleCommandLineArgsProvider(TaskExecution taskExecution) {
+		Assert.notNull(taskExecution, "A taskExecution is required");
+
+		this.taskExecution = taskExecution;
+	}
+
 	@Override
-	public Map<String, String> getEnvironmentVariables(ExecutionContext executionContext) {
-		return Collections.emptyMap();
+	public List<String> getCommandLineArgs(ExecutionContext executionContext) {
+		return this.taskExecution.getArguments();
 	}
 }

--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/SimpleEnvironmentVariablesProvider.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/SimpleEnvironmentVariablesProvider.java
@@ -42,6 +42,8 @@ public class SimpleEnvironmentVariablesProvider implements EnvironmentVariablesP
 
 	private Map<String, String> environmentProperties = new HashMap<>(0);
 
+	private boolean includeCurrentEnvironment = true;
+
 	/**
 	 * @param environment The {@link Environment} for this context
 	 */
@@ -57,11 +59,19 @@ public class SimpleEnvironmentVariablesProvider implements EnvironmentVariablesP
 		this.environmentProperties = environmentProperties;
 	}
 
+	public void setIncludeCurrentEnvironment(boolean includeCurrentEnvironment) {
+		this.includeCurrentEnvironment = includeCurrentEnvironment;
+	}
+
 	@Override
 	public Map<String, String> getEnvironmentVariables(ExecutionContext executionContext) {
 
 		Map<String, String> environmentProperties = new HashMap<>(this.environmentProperties.size());
-		environmentProperties.putAll(getCurrentEnvironmentProperties());
+
+		if(includeCurrentEnvironment) {
+			environmentProperties.putAll(getCurrentEnvironmentProperties());
+		}
+
 		environmentProperties.putAll(this.environmentProperties);
 
 		return environmentProperties;

--- a/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/DeployerPartitionHandlerTests.java
+++ b/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/DeployerPartitionHandlerTests.java
@@ -149,7 +149,7 @@ public class DeployerPartitionHandlerTests {
 
 		AppDefinition appDefinition = request.getDefinition();
 
-		assertEquals("partitionedJobTask:partitionedJob:step1:partition1", appDefinition.getName());
+		assertEquals("partitionedJobTask", appDefinition.getName());
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_JOB_EXECUTION_ID, "1")));
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_EXECUTION_ID, "4")));
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_NAME, "step1")));
@@ -362,7 +362,7 @@ public class DeployerPartitionHandlerTests {
 
 		AppDefinition appDefinition = request.getDefinition();
 
-		assertEquals("partitionedJobTask:partitionedJob:step1:partition1", appDefinition.getName());
+		assertEquals("partitionedJobTask", appDefinition.getName());
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_JOB_EXECUTION_ID, "1")));
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_EXECUTION_ID, "4")));
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_NAME, "step1")));
@@ -426,7 +426,7 @@ public class DeployerPartitionHandlerTests {
 
 		AppDefinition appDefinition = request.getDefinition();
 
-		assertEquals("partitionedJobTask:partitionedJob:step1:partition1", appDefinition.getName());
+		assertEquals("partitionedJobTask", appDefinition.getName());
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_JOB_EXECUTION_ID, "1")));
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_EXECUTION_ID, "4")));
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_NAME, "step1")));
@@ -608,7 +608,7 @@ public class DeployerPartitionHandlerTests {
 
 		AppDefinition appDefinition = request.getDefinition();
 
-		assertEquals("partitionedJobTask:partitionedJob:step1:partition1", appDefinition.getName());
+		assertEquals("partitionedJobTask", appDefinition.getName());
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_JOB_EXECUTION_ID, "1")));
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_EXECUTION_ID, "4")));
 		assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_NAME, "step1")));
@@ -661,7 +661,27 @@ public class DeployerPartitionHandlerTests {
 		Collections.sort(allRequests, new Comparator<AppDeploymentRequest>() {
 			@Override
 			public int compare(AppDeploymentRequest o1, AppDeploymentRequest o2) {
-				return o1.getDefinition().getName().compareTo(o2.getDefinition().getName());
+				List<String> commandlineArguments = o1.getCommandlineArguments();
+
+				String o1Command = "";
+				for (String commandlineArgument : commandlineArguments) {
+					if(commandlineArgument.contains(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_EXECUTION_ID)) {
+						o1Command = commandlineArgument;
+						break;
+					}
+				}
+
+				commandlineArguments = o2.getCommandlineArguments();
+
+				String o2Command = "";
+				for (String commandlineArgument : commandlineArguments) {
+					if(commandlineArgument.contains(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_EXECUTION_ID)) {
+						o2Command = commandlineArgument;
+						break;
+					}
+				}
+
+				return o1Command.compareTo(o2Command);
 			}
 		});
 
@@ -671,7 +691,7 @@ public class DeployerPartitionHandlerTests {
 			assertEquals(0, request.getDeploymentProperties().size());
 
 			AppDefinition appDefinition = request.getDefinition();
-			assertEquals("partitionedJobTask:partitionedJob:step1:partition" + (i - 3), appDefinition.getName());
+			assertEquals("partitionedJobTask", appDefinition.getName());
 			assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_JOB_EXECUTION_ID, "1")));
 			assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_EXECUTION_ID, String.valueOf(i))));
 			assertTrue(request.getCommandlineArguments().contains(formatArgs(DeployerPartitionHandler.SPRING_CLOUD_TASK_STEP_NAME, "step1")));

--- a/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/NoOpEnvironmentVariablesProviderTests.java
+++ b/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/NoOpEnvironmentVariablesProviderTests.java
@@ -15,29 +15,31 @@
  */
 package org.springframework.cloud.task.batch.partition;
 
-import java.util.Collections;
 import java.util.Map;
 
-import org.springframework.batch.item.ExecutionContext;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
- * A simple no-op implementation of the {@link EnvironmentVariablesProvider}.  It returns
- * an empty {@link Map}.
- *
  * @author Michael Minella
- *
- * @since 1.0.2
  */
-public class NoOpEnvironmentVariablesProvider implements EnvironmentVariablesProvider {
+public class NoOpEnvironmentVariablesProviderTests {
 
-	/**
-	 *
-	 * @param executionContext the {@link ExecutionContext} associated with the worker's
-	 * 			step
-	 * @return an empty {@link Map}
-	 */
-	@Override
-	public Map<String, String> getEnvironmentVariables(ExecutionContext executionContext) {
-		return Collections.emptyMap();
+	private NoOpEnvironmentVariablesProvider provider;
+
+	@Before
+	public void setUp() {
+		this.provider = new NoOpEnvironmentVariablesProvider();
+	}
+
+	@Test
+	public void test() {
+		Map<String, String> environmentVariables = this.provider.getEnvironmentVariables(null);
+		assertNotNull(environmentVariables);
+		assertTrue(environmentVariables.isEmpty());
+
+		Map<String, String> environmentVariables2 = this.provider.getEnvironmentVariables(null);
+		assertTrue(environmentVariables == environmentVariables2);
 	}
 }

--- a/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/PassThroughCommandLineArgsProviderTests.java
+++ b/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/PassThroughCommandLineArgsProviderTests.java
@@ -15,29 +15,32 @@
  */
 package org.springframework.cloud.task.batch.partition;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
 
-import org.springframework.batch.item.ExecutionContext;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
- * A simple no-op implementation of the {@link EnvironmentVariablesProvider}.  It returns
- * an empty {@link Map}.
- *
  * @author Michael Minella
- *
- * @since 1.0.2
  */
-public class NoOpEnvironmentVariablesProvider implements EnvironmentVariablesProvider {
+public class PassThroughCommandLineArgsProviderTests {
 
-	/**
-	 *
-	 * @param executionContext the {@link ExecutionContext} associated with the worker's
-	 * 			step
-	 * @return an empty {@link Map}
-	 */
-	@Override
-	public Map<String, String> getEnvironmentVariables(ExecutionContext executionContext) {
-		return Collections.emptyMap();
+	@Test(expected = IllegalArgumentException.class)
+	public void testNull() {
+		new PassThroughCommandLineArgsProvider(null);
+	}
+
+	@Test
+	public void test() {
+		List<String> args = Arrays.asList("foo", "bar", "baz");
+
+		CommandLineArgsProvider provider = new PassThroughCommandLineArgsProvider(args);
+
+		List<String> commandLineArgs = provider.getCommandLineArgs(null);
+
+		assertEquals("foo", commandLineArgs.get(0));
+		assertEquals("bar", commandLineArgs.get(1));
+		assertEquals("baz", commandLineArgs.get(2));
 	}
 }

--- a/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/SimpleCommandLineArgsProviderTests.java
+++ b/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/SimpleCommandLineArgsProviderTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.task.batch.partition;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.springframework.cloud.task.repository.TaskExecution;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Michael Minella
+ */
+public class SimpleCommandLineArgsProviderTests {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testNullConstructorArg() {
+		new SimpleCommandLineArgsProvider(null);
+	}
+
+	@Test
+	public void test() {
+		TaskExecution taskExecution = new TaskExecution();
+		taskExecution.setArguments(Arrays.asList("foo", "bar", "baz"));
+
+		CommandLineArgsProvider provider = new SimpleCommandLineArgsProvider(taskExecution);
+
+		List<String> commandLineArgs = provider.getCommandLineArgs(null);
+
+		assertEquals("foo", commandLineArgs.get(0));
+		assertEquals("bar", commandLineArgs.get(1));
+		assertEquals("baz", commandLineArgs.get(2));
+	}
+}

--- a/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/launcher/TaskLauncherSinkTests.java
+++ b/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/launcher/TaskLauncherSinkTests.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.deployer.spi.local.LocalDeployerProperties;
 import org.springframework.cloud.deployer.spi.local.LocalTaskLauncher;
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
@@ -59,7 +59,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = {TaskLauncherSinkApplication.class, TaskLauncherSinkTests.TaskLauncherConfiguration.class})
+@SpringBootTest(classes = {TaskLauncherSinkApplication.class, TaskLauncherSinkTests.TaskLauncherConfiguration.class})
 public class TaskLauncherSinkTests {
 
 	private final static int WAIT_INTERVAL = 500;

--- a/spring-cloud-task-samples/partitioned-batch-job/pom.xml
+++ b/spring-cloud-task-samples/partitioned-batch-job/pom.xml
@@ -61,8 +61,8 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
+			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc</artifactId>
@@ -74,7 +74,7 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>

--- a/spring-cloud-task-samples/partitioned-batch-job/src/main/resources/application.properties
+++ b/spring-cloud-task-samples/partitioned-batch-job/src/main/resources/application.properties
@@ -1,3 +1,4 @@
-spring.application.name=Partitioned Batch Job Task
+spring.application.name=PartitionedBatchJobTask
 logging.level.org.springframework.cloud.task=DEBUG
 maven.remoteRepositories.springRepo.url=https://repo.spring.io/libs-snapshot
+


### PR DESCRIPTION
This commit adds on an abstraction for the providing unique command line
arugements for each worker.  It also updates the partitioned job sample
to be able to successfully be run on CloudFoundry.

Resolves spring-cloud/spring-cloud-task#193
Resolves spring-cloud/spring-cloud-task#192