### PR TITLE
Correct typo of closecontext.enable property in docs (Obvious Fix)

### DIFF
--- a/spring-cloud-task-docs/src/main/asciidoc/features.adoc
+++ b/spring-cloud-task-docs/src/main/asciidoc/features.adoc
@@ -49,7 +49,7 @@ updated in the repository with the results.
 
 NOTE: At the completion of a task (all `*Runner#run` methods are called and the task
 repository has been updated) the `ApplicationContext` will be closed by default.  This
-behavior can be overriden by setting the property `spring.cloud.task.closecontext.enabled`
+behavior can be overriden by setting the property `spring.cloud.task.closecontext.enable`
 to false.
 
 [[features-task-execution-details]]


### PR DESCRIPTION
https://github.com/spring-cloud/spring-cloud-task/blob/master/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java#L92