### PR TITLE
Refactor to clense task name

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskNameResolver.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskNameResolver.java
@@ -55,7 +55,7 @@ public class SimpleTaskNameResolver implements TaskNameResolver, ApplicationCont
 			return configuredName;
 		}
 		else {
-			return context.getId();
+			return context.getId().replace(":", "_");
 		}
 	}
 }

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskNameResolverTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskNameResolverTests.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.cloud.task.repository.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
 
 import org.springframework.context.support.GenericApplicationContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Michael Minella
@@ -35,6 +35,17 @@ public class SimpleTaskNameResolverTests {
 		taskNameResolver.setApplicationContext(context);
 
 		assertTrue(taskNameResolver.getTaskName().startsWith("org.springframework.context.support.GenericApplicationContext"));
+	}
+
+	@Test
+	public void testWithProfile() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.setId("foo:bar");
+
+		SimpleTaskNameResolver taskNameResolver = new SimpleTaskNameResolver();
+		taskNameResolver.setApplicationContext(context);
+
+		assertTrue(taskNameResolver.getTaskName().startsWith("foo_bar"));
 	}
 
 	@Test


### PR DESCRIPTION
When using Spring Boot, the id of the application context can be a colon
delimited string of values.  By default, Spring Cloud Task uses this
value as the task name.  However, when using JMX, this can cause issues.
This commit updates the SimpleTaskNameResolver to clense the colons and
replace them with underscores.

Resolves #280