### PR TITLE
Removed dependencies on Spring Boot starters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
 				<artifactId>spring-cloud-stream-test-support</artifactId>
 				<version>${spring-cloud-stream.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>commons-logging</groupId>
+				<artifactId>commons-logging-api</artifactId>
+				<version>${commons-logging.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -139,6 +144,7 @@
 		<spring-cloud-deployer-resource-support.version>1.2.0.M3</spring-cloud-deployer-resource-support.version>
 		<spring-cloud-deployer-resource-maven.version>1.2.0.M3</spring-cloud-deployer-resource-maven.version>
 		<spring-batch.version>3.0.7.RELEASE</spring-batch.version>
+		<commons-logging.version>1.1</commons-logging.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<sonar.jacoco.reportPath>${project.build.directory}/coverage-reports/jacoco-ut.exec</sonar.jacoco.reportPath>

--- a/spring-cloud-task-batch/pom.xml
+++ b/spring-cloud-task-batch/pom.xml
@@ -46,6 +46,10 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-task-core/pom.xml
+++ b/spring-cloud-task-core/pom.xml
@@ -17,7 +17,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -31,6 +31,11 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-task-stream/pom.xml
+++ b/spring-cloud-task-stream/pom.xml
@@ -35,8 +35,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-logging</artifactId>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
This commit removes the dependency on any Spring Boot starters.
Starters are still used in the test scope, but should not impact the
library's dependencies.

Resolves #294