### PR TITLE
Prevent a task from starting if an instance with the same name is run…

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/TaskProperties.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/TaskProperties.java
@@ -62,6 +62,16 @@ public class TaskProperties {
 	 */
 	private Boolean closecontextEnabled = true;
 
+	/**
+	 * When set to true the
+	 * {@link org.springframework.cloud.task.listener.TaskLifecycleListener#doTaskStart()}
+	 * will check to see if a task execution with the same task name is already
+	 * running (by checking to see if the endTime is null).  If a task is still
+	 * running then it will throw a
+	 * {@link org.springframework.cloud.task.listener.TaskExecutionException}.
+	 */
+	private Boolean singleInstanceEnabled = false;
+
 	public String getExternalExecutionId() {
 		return externalExecutionId;
 	}
@@ -122,5 +132,13 @@ public class TaskProperties {
 
 	public void setParentExecutionId(Long parentExecutionId) {
 		this.parentExecutionId = parentExecutionId;
+	}
+
+	public Boolean getSingleInstanceEnabled() {
+		return singleInstanceEnabled;
+	}
+
+	public void setSingleInstanceEnabled(Boolean singleInstanceEnabled) {
+		this.singleInstanceEnabled = singleInstanceEnabled;
 	}
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
@@ -64,6 +64,7 @@ import org.springframework.util.Assert;
  * property <code>spring.cloud.task.closecontext.enable</code> (defaults to true).
  *
  * @author Michael Minella
+ * @author Glenn Renfro
  */
 public class TaskLifecycleListener implements ApplicationListener<ApplicationEvent>, SmartLifecycle, DisposableBean {
 
@@ -194,6 +195,13 @@ public class TaskLifecycleListener implements ApplicationListener<ApplicationEve
 
 			if(this.applicationArguments != null) {
 				args = Arrays.asList(this.applicationArguments.getSourceArgs());
+			}
+			if(taskProperties.getSingleInstanceEnabled() &&
+					taskExplorer.getRunningTaskExecutionCountByTaskName(
+							this.taskNameResolver.getTaskName()) > 0 ) {
+				throw new TaskExecutionException(String.format(
+						"Task with name \"%s\" is currently running.",
+						this.taskNameResolver.getTaskName()));
 			}
 			if(taskProperties.getExecutionid() != null) {
 				TaskExecution taskExecution = taskExplorer.getTaskExecution(taskProperties.getExecutionid());

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskExplorer.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskExplorer.java
@@ -64,6 +64,14 @@ public interface TaskExplorer {
 	long getTaskExecutionCountByTaskName(String taskName);
 
 	/**
+	 * Get number of executions for a taskName that are running.
+	 *
+	 * @param taskName the name of the task to be searched
+	 * @return the number of running tasks that have the taskname specified
+	 */
+	long getRunningTaskExecutionCountByTaskName(String taskName);
+
+	/**
 	 * Retrieves current number of task executions.
 	 *
 	 * @return current number of task executions.

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorer.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorer.java
@@ -68,6 +68,11 @@ public class SimpleTaskExplorer implements TaskExplorer {
 	}
 
 	@Override
+	public long getRunningTaskExecutionCountByTaskName(String taskName) {
+		return taskExecutionDao.getRunningTaskExecutionCountByTaskName(taskName);
+	}
+
+	@Override
 	public long getTaskExecutionCount() {
 		return taskExecutionDao.getTaskExecutionCount();
 	}

--- a/spring-cloud-task-docs/src/main/asciidoc/features.adoc
+++ b/spring-cloud-task-docs/src/main/asciidoc/features.adoc
@@ -205,6 +205,22 @@ following property on the child task:
 
 ```
 spring.cloud.task.parent-execution-id=<parentExecutionTaskId>
+
+```
+[[features-single_instance_enabled]]
+=== Parent Task Id
+
+Spring Cloud Task allows a user to establish whether a task should execute if
+another task with the same `spring.cloud.task.name` is executing.  If
+`spring.cloud.task.single-instance-enabled` is set to true then the current
+task instance will check the datastore to see if a TaskExecution with
+the same `spring.cloud.task.name` is running.  If so this Task instance will
+throw a TaskExecutionException prior to making any entries into the datastore.
+If `spring.cloud.task.single-instance-enabled`  is set to false (the default)
+then this check will not be performed and the task instance will be executed.
+To configure this feature add the following property on the task:
+```
+spring.cloud.task.single-instance-enabled=<true or false>
 ```
 
 [[features-task-configurer]]


### PR DESCRIPTION
…ning.

feature is disabled by default.  To enable it set spring.cloud.task.singleInstanceEnabled=true.
resolves #81

added docs