### PR TITLE
Updated tests to remove deprecated code from tests

### DIFF
--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/DeployerPartitionHandler.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/DeployerPartitionHandler.java
@@ -200,7 +200,7 @@ public class DeployerPartitionHandler implements PartitionHandler, EnvironmentAw
 	/**
 	 * Map of deployment properties to be used by the {@link TaskLauncher}
 	 *
-	 * @param deploymentProperties properites to be used by the {@link TaskLauncher}
+	 * @param deploymentProperties properties to be used by the {@link TaskLauncher}
 	 */
 	public void setDeploymentProperties(Map<String, String> deploymentProperties) {
 		this.deploymentProperties = deploymentProperties;

--- a/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/listener/TaskBatchExecutionListenerTests.java
+++ b/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/listener/TaskBatchExecutionListenerTests.java
@@ -99,7 +99,7 @@ public class TaskBatchExecutionListenerTests {
 	private void validateContext() {
 		TaskExplorer taskExplorer = this.applicationContext.getBean(TaskExplorer.class);
 
-		Page<TaskExecution> page = taskExplorer.findTaskExecutionsByName("application", new PageRequest(0, 1));
+		Page<TaskExecution> page = taskExplorer.findTaskExecutionsByName("application", PageRequest.of(0, 1));
 
 		Set<Long> jobExecutionIds = taskExplorer.getJobExecutionIdsByTaskExecutionId(page.iterator().next().getExecutionId());
 
@@ -117,7 +117,7 @@ public class TaskBatchExecutionListenerTests {
 
 		TaskExplorer taskExplorer = this.applicationContext.getBean(TaskExplorer.class);
 
-		Page<TaskExecution> page = taskExplorer.findTaskExecutionsByName("application", new PageRequest(0, 1));
+		Page<TaskExecution> page = taskExplorer.findTaskExecutionsByName("application", PageRequest.of(0, 1));
 
 		Set<Long> jobExecutionIds = taskExplorer.getJobExecutionIdsByTaskExecutionId(page.iterator().next().getExecutionId());
 

--- a/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/SimpleCommandLineArgsProviderTests.java
+++ b/spring-cloud-task-batch/src/test/java/org/springframework/cloud/task/batch/partition/SimpleCommandLineArgsProviderTests.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class SimpleCommandLineArgsProviderTests {
 
+	//TODO remove when SimpleCommandLineArgsProvider is removed.
 	@Test(expected = IllegalArgumentException.class)
 	public void testNullConstructorArg() {
 		new SimpleCommandLineArgsProvider(null);
@@ -40,7 +41,8 @@ public class SimpleCommandLineArgsProviderTests {
 		TaskExecution taskExecution = new TaskExecution();
 		taskExecution.setArguments(Arrays.asList("foo", "bar", "baz"));
 
-		CommandLineArgsProvider provider = new SimpleCommandLineArgsProvider(taskExecution);
+		SimpleCommandLineArgsProvider provider = new SimpleCommandLineArgsProvider();
+		provider.onTaskStartup(taskExecution);
 
 		List<String> commandLineArgs = provider.getCommandLineArgs(null);
 
@@ -59,7 +61,8 @@ public class SimpleCommandLineArgsProviderTests {
 		TaskExecution taskExecution = new TaskExecution();
 		taskExecution.setArguments(Arrays.asList("foo", "bar", "baz"));
 
-		SimpleCommandLineArgsProvider provider = new SimpleCommandLineArgsProvider(taskExecution);
+		SimpleCommandLineArgsProvider provider = new SimpleCommandLineArgsProvider();
+		provider.onTaskStartup(taskExecution);
 		provider.setAppendedArgs(appendedValues);
 
 		List<String> commandLineArgs = provider.getCommandLineArgs(null);
@@ -78,7 +81,8 @@ public class SimpleCommandLineArgsProviderTests {
 		TaskExecution taskExecution = new TaskExecution();
 		taskExecution.setArguments(Arrays.asList("foo", "bar", "baz"));
 
-		SimpleCommandLineArgsProvider provider = new SimpleCommandLineArgsProvider(taskExecution);
+		SimpleCommandLineArgsProvider provider = new SimpleCommandLineArgsProvider();
+		provider.onTaskStartup(taskExecution);
 		provider.setAppendedArgs(null);
 
 		List<String> commandLineArgs = provider.getCommandLineArgs(null);

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskLifecycleListener.java
@@ -29,7 +29,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ExitCodeEvent;
 import org.springframework.boot.context.event.ApplicationFailedEvent;

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/database/support/AbstractSqlPagingQueryProvider.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/database/support/AbstractSqlPagingQueryProvider.java
@@ -136,7 +136,7 @@ public abstract class AbstractSqlPagingQueryProvider implements PagingQueryProvi
 
 	@Override
 	public void init(DataSource dataSource) throws Exception {
-		Assert.notNull(dataSource);
+		Assert.notNull(dataSource, "DataSource must not be null");
 		Assert.hasLength(selectClause, "selectClause must be specified");
 		Assert.hasLength(fromClause, "fromClause must be specified");
 		Assert.notEmpty(sortKeys, "sortKey must be specified");

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskLifecycleListenerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/listener/TaskLifecycleListenerTests.java
@@ -212,9 +212,9 @@ public class TaskLifecycleListenerTests {
 			Integer exitCode, Throwable exception, String externalExecutionId,
 			Long parentExecutionId) {
 
-		Sort sort = new Sort("id");
+		Sort sort = Sort.by("id");
 
-		PageRequest request = new PageRequest(0, Integer.MAX_VALUE, sort);
+		PageRequest request = PageRequest.of(0, Integer.MAX_VALUE, sort);
 
 		Page<TaskExecution> taskExecutionsByName = this.taskExplorer.findTaskExecutionsByName("testTask",
 				request);

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/dao/JdbcTaskExecutionDaoTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/dao/JdbcTaskExecutionDaoTests.java
@@ -138,7 +138,7 @@ public class JdbcTaskExecutionDaoTests {
 	@DirtiesContext
 	public void testFindAllPageableSort()  {
 		initializeRepositoryNotInOrder();
-		Sort sort = new Sort(new Sort.Order(Sort.Direction.ASC,
+		Sort sort = Sort.by(new Sort.Order(Sort.Direction.ASC,
 				"EXTERNAL_EXECUTION_ID"));
 		Iterator<TaskExecution> iter = getPageIterator(0, 2, sort);
 		TaskExecution taskExecution = iter.next();
@@ -202,8 +202,8 @@ public class JdbcTaskExecutionDaoTests {
 
 	private Iterator<TaskExecution> getPageIterator(int pageNum, int pageSize, Sort sort) {
 		Pageable pageable = (sort == null) ?
-				new PageRequest(pageNum, pageSize) :
-				new PageRequest(pageNum, pageSize, sort);
+				PageRequest.of(pageNum, pageSize) :
+				PageRequest.of(pageNum, pageSize, sort);
 		Page<TaskExecution> page = dao.findAll(pageable);
 		assertEquals(3, page.getTotalElements());
 		assertEquals(2, page.getTotalPages());

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/database/support/FindAllPagingQueryProviderTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/database/support/FindAllPagingQueryProviderTests.java
@@ -37,7 +37,7 @@ public class FindAllPagingQueryProviderTests {
 
 	private String databaseProductName;
 	private String expectedQuery;
-	private Pageable pageable = new PageRequest(0, 10);
+	private Pageable pageable = PageRequest.of(0, 10);
 
 	@Parameterized.Parameters
 	public static Collection<Object[]> data() {

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/database/support/InvalidPagingQueryProviderTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/database/support/InvalidPagingQueryProviderTests.java
@@ -28,7 +28,7 @@ public class InvalidPagingQueryProviderTests {
 
 	@Test(expected = IllegalStateException.class)
 	public void testInvalidDatabase() throws Exception{
-		Pageable pageable = new PageRequest(0, 10);
-		String actualQuery = TestDBUtils.getPagingQueryProvider("Invalid").getPageQuery(pageable);
+		Pageable pageable = PageRequest.of(0, 10);
+		TestDBUtils.getPagingQueryProvider("Invalid").getPageQuery(pageable);
 	}
 }

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/database/support/WhereClausePagingQueryProviderTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/database/support/WhereClausePagingQueryProviderTests.java
@@ -38,7 +38,7 @@ public class WhereClausePagingQueryProviderTests {
 
 	private String databaseProductName;
 	private String expectedQuery;
-	private Pageable pageable = new PageRequest(0, 10);
+	private Pageable pageable = PageRequest.of(0, 10);
 
 	@Parameterized.Parameters
 	public static Collection<Object[]> data() {

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorerTests.java
@@ -171,7 +171,7 @@ public class SimpleTaskExplorerTests {
 					createTaskExecution(getSimpleTaskExecution());
 			expectedResults.put(expectedTaskExecution.getExecutionId(), expectedTaskExecution);
 		}
-		Pageable pageable = new PageRequest(0, 10);
+		Pageable pageable = PageRequest.of(0, 10);
 
 		Page<TaskExecution> actualResults = taskExplorer.findRunningTaskExecutions(TASK_NAME, pageable);
 		assertEquals(String.format(
@@ -206,7 +206,7 @@ public class SimpleTaskExplorerTests {
 			expectedResults.put(expectedTaskExecution.getExecutionId(), expectedTaskExecution);
 		}
 
-		Pageable pageable = new PageRequest(0, 10);
+		Pageable pageable = PageRequest.of(0, 10);
 		Page<TaskExecution> resultSet = taskExplorer.findTaskExecutionsByName(TASK_NAME, pageable);
 		assertEquals(String.format(
 				"Running task count for task name did not match expected result for testType %s",
@@ -239,25 +239,25 @@ public class SimpleTaskExplorerTests {
 
 	@Test
 	public void findAllExecutionsOffBoundry() {
-		Pageable pageable = new PageRequest(0, 10);
+		Pageable pageable = PageRequest.of(0, 10);
 		verifyPageResults(pageable, 103);
 	}
 
 	@Test
 	public void findAllExecutionsOffBoundryByOne() {
-		Pageable pageable = new PageRequest(0, 10);
+		Pageable pageable = PageRequest.of(0, 10);
 		verifyPageResults(pageable, 101);
 	}
 
 	@Test
 	public void findAllExecutionsOnBoundry() {
-		Pageable pageable = new PageRequest(0, 10);
+		Pageable pageable = PageRequest.of(0, 10);
 		verifyPageResults(pageable, 100);
 	}
 
 	@Test
 	public void findAllExecutionsNoResult() {
-		Pageable pageable = new PageRequest(0, 10);
+		Pageable pageable = PageRequest.of(0, 10);
 		verifyPageResults(pageable, 0);
 	}
 
@@ -285,7 +285,7 @@ public class SimpleTaskExplorerTests {
 				taskPage.getTotalElements());
 
 		//Verify pagination
-		Pageable actualPageable = new PageRequest(0, pageable.getPageSize());
+		Pageable actualPageable = PageRequest.of(0, pageable.getPageSize());
 		boolean hasMorePages = taskPage.hasContent();
 		int pageNumber = 0;
 		int elementCount = 0;

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskRepositoryMapTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskRepositoryMapTests.java
@@ -28,7 +28,6 @@ import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.cloud.task.repository.dao.MapTaskExecutionDao;
 import org.springframework.cloud.task.util.TaskExecutionCreator;
-import org.springframework.cloud.task.util.TestDBUtils;
 import org.springframework.cloud.task.util.TestVerifierUtils;
 
 import static org.springframework.test.util.AssertionErrors.assertTrue;

--- a/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/executionid/TaskStartTests.java
+++ b/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/executionid/TaskStartTests.java
@@ -55,7 +55,6 @@ import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.SocketUtils;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -139,7 +138,7 @@ public class TaskStartTests {
 		getTaskApplication(1).run(new String[0]);
 		assertTrue(waitForDBToBePopulated());
 
-		Page<TaskExecution> taskExecutions = taskExplorer.findAll(new PageRequest(0, 10));
+		Page<TaskExecution> taskExecutions = taskExplorer.findAll(PageRequest.of(0, 10));
 		TaskExecution te = taskExecutions.iterator().next();
 		assertEquals("Only one row is expected", 1, taskExecutions.getTotalElements());
 		assertEquals("return code should be 0", 0, taskExecutions.iterator().next().getExitCode().intValue());
@@ -155,7 +154,7 @@ public class TaskStartTests {
 		getTaskApplication(1).run(new String[0]);
 		assertTrue(waitForDBToBePopulated());
 
-		Page<TaskExecution> taskExecutions = taskExplorer.findAll(new PageRequest(0, 10));
+		Page<TaskExecution> taskExecutions = taskExplorer.findAll(PageRequest.of(0, 10));
 		TaskExecution te = taskExecutions.iterator().next();
 		assertEquals("Only one row is expected", 1, taskExecutions.getTotalElements());
 		assertEquals("return code should be 0", 0, taskExecutions.iterator().next().getExitCode().intValue());

--- a/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/launcher/TaskLauncherSinkTests.java
+++ b/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/launcher/TaskLauncherSinkTests.java
@@ -139,7 +139,7 @@ public class TaskLauncherSinkTests {
 		launchTask(URL);
 		assertTrue(waitForDBToBePopulated());
 
-		Page<TaskExecution> taskExecutions = taskExplorer.findAll(new PageRequest(0, 10));
+		Page<TaskExecution> taskExecutions = taskExplorer.findAll(PageRequest.of(0, 10));
 		TaskExecution te = taskExecutions.iterator().next();
 		assertEquals("Only one row is expected", 1, taskExecutions.getTotalElements());
 		assertEquals("return code should be 0", 0, taskExecutions.iterator().next().getExitCode().intValue());

--- a/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/listener/BatchExecutionEventTests.java
+++ b/spring-cloud-task-integration-tests/src/test/java/org/springframework/cloud/task/listener/BatchExecutionEventTests.java
@@ -27,7 +27,6 @@ import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;

--- a/spring-cloud-task-samples/jpa-sample/src/test/java/io/spring/JpaApplicationTests.java
+++ b/spring-cloud-task-samples/jpa-sample/src/test/java/io/spring/JpaApplicationTests.java
@@ -101,7 +101,7 @@ public class JpaApplicationTests {
 		assertTrue("Unable to find the insert message: " + output, output.contains(INSERT_MESSAGE));
 		JdbcTemplate template = new JdbcTemplate(this.dataSource);
 		Map<String, Object> result = template.queryForMap("Select * from TASK_RUN_OUTPUT");
-		assertThat(((Long) result.get("ID")), is(1L));
+		assertThat((result.get("ID")), is(1L));
 		assertThat(((String) result.get("OUTPUT")), containsString("Executed at"));
 	}
 

--- a/spring-cloud-task-samples/partitioned-batch-job/src/main/java/io/spring/JobConfiguration.java
+++ b/spring-cloud-task-samples/partitioned-batch-job/src/main/java/io/spring/JobConfiguration.java
@@ -43,7 +43,6 @@ import org.springframework.cloud.deployer.resource.support.DelegatingResourceLoa
 import org.springframework.cloud.deployer.spi.task.TaskLauncher;
 import org.springframework.cloud.task.batch.partition.DeployerPartitionHandler;
 import org.springframework.cloud.task.batch.partition.DeployerStepExecutionHandler;
-import org.springframework.cloud.task.batch.partition.NoOpEnvironmentVariablesProvider;
 import org.springframework.cloud.task.batch.partition.PassThroughCommandLineArgsProvider;
 import org.springframework.cloud.task.batch.partition.SimpleEnvironmentVariablesProvider;
 import org.springframework.context.ConfigurableApplicationContext;

--- a/spring-cloud-task-samples/partitioned-batch-job/src/test/java/org/springframework/cloud/task/partitioner/TaskPartitionerTests.java
+++ b/spring-cloud-task-samples/partitioned-batch-job/src/test/java/org/springframework/cloud/task/partitioner/TaskPartitionerTests.java
@@ -38,7 +38,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.SocketUtils;
 
@@ -97,7 +96,7 @@ public class TaskPartitionerTests {
 						"--spring.datasource.username=" + DATASOURCE_USER_NAME,
 						"--spring.datasource.driverClassName=" + DATASOURCE_DRIVER_CLASS_NAME);
 
-		Page<TaskExecution> taskExecutions = taskExplorer.findAll(new PageRequest(0, 10));
+		Page<TaskExecution> taskExecutions = taskExplorer.findAll(PageRequest.of(0, 10));
 		assertEquals("Five rows are expected", 5, taskExecutions.getTotalElements());
 		assertEquals("Only One master is expected", 1, taskExplorer.getTaskExecutionCountByTaskName("Partitioned Batch Job Task:master:0"));
 		assertEquals("4 partitions is expected", 4, taskExplorer.getTaskExecutionCountByTaskName("Partitioned Batch Job Task:worker:0"));

--- a/spring-cloud-task-samples/taskprocessor/src/test/java/io/spring/TaskProcessorApplicationTests.java
+++ b/spring-cloud-task-samples/taskprocessor/src/test/java/io/spring/TaskProcessorApplicationTests.java
@@ -35,7 +35,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.springframework.cloud.stream.test.matcher.MessageQueueMatcher.receivesPayloadThat;
 
 /**
  * @author Glenn Renfro

--- a/spring-cloud-task-samples/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TimestampTaskPropertiesTests.java
+++ b/spring-cloud-task-samples/timestamp/src/test/java/org/springframework/cloud/task/timestamp/TimestampTaskPropertiesTests.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,7 +32,8 @@ public class TimestampTaskPropertiesTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void testEmptyFormat() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-		EnvironmentTestUtils.addEnvironment(context, "format:");
+		TestPropertyValues testPropertyValues = TestPropertyValues.of("format:");
+		testPropertyValues.applyTo(context);
 		context.register(Conf.class);
 		context.refresh();
 		TimestampTaskProperties properties = context.getBean(TimestampTaskProperties.class);

--- a/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/BatchEventAutoConfiguration.java
+++ b/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/BatchEventAutoConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.Output;
@@ -38,7 +37,6 @@ import org.springframework.cloud.task.listener.TaskLifecycleListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.integration.gateway.GatewayProxyFactoryBean;
 import org.springframework.messaging.MessageChannel;
 
 /**

--- a/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/support/ExitStatus.java
+++ b/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/support/ExitStatus.java
@@ -33,7 +33,7 @@ public class ExitStatus {
 	}
 
 	public ExitStatus(org.springframework.batch.core.ExitStatus exitStatus) {
-		Assert.notNull(exitStatus);
+		Assert.notNull(exitStatus, "exitStatus must not be null.");
 
 		this.exitCode = exitStatus.getExitCode();
 		this.exitDescription = exitStatus.getExitDescription();

--- a/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/support/JobExecutionEvent.java
+++ b/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/support/JobExecutionEvent.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.task.batch.listener.support;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/support/JobInstanceEvent.java
+++ b/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/support/JobInstanceEvent.java
@@ -36,7 +36,7 @@ public class JobInstanceEvent extends Entity {
 
 	public JobInstanceEvent(Long id, String jobName) {
 		super(id);
-		Assert.hasLength(jobName);
+		Assert.hasLength(jobName, "jobName must have length greater than zero.");
 		this.jobName = jobName;
 	}
 

--- a/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/support/StepExecutionEvent.java
+++ b/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/support/StepExecutionEvent.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.task.batch.listener.support;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;


### PR DESCRIPTION
* cleanup removing unused headers
* Updated asserts in code base that needed messages (marked as deprecated)
* left one test that was testing a deprecated constructor.  When that code is removed we can remove that test.
* some other cleanup

resolves #338