### PR TITLE
SimpleTaskConfiguration ignores proxy beans when validating datasources

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskConfiguration.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskConfiguration.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.task.configuration;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
@@ -24,6 +26,7 @@ import javax.sql.DataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -175,9 +178,11 @@ public class SimpleTaskConfiguration {
 		}
 	}
 
-	private void verifyEnvironment(){
+	private void verifyEnvironment() {
 		int configurers = this.context.getBeanNamesForType(TaskConfigurer.class).length;
-		int dataSources = this.context.getBeanNamesForType(DataSource.class).length;
+		// retrieve the count of dataSources (without instantiating them) excluding DataSource proxy beans
+		long dataSources = Arrays.stream(this.context.getBeanNamesForType(DataSource.class))
+				.filter((name -> !ScopedProxyUtils.isScopedTarget(name))).collect(Collectors.counting());
 
 		if(configurers == 0 && dataSources > 1) {
 			throw new IllegalStateException("To use the default TaskConfigurer the context must contain no more than" +

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/SimpleTaskConfigurationTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/SimpleTaskConfigurationTests.java
@@ -174,6 +174,7 @@ public class SimpleTaskConfigurationTests {
 
 	}
 
+	@Configuration
 	public static class DataSourceProxyConfiguration {
 
 		@Autowired

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/SimpleTaskConfigurationTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/SimpleTaskConfigurationTests.java
@@ -48,12 +48,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.PropertiesPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -80,11 +74,11 @@ public class SimpleTaskConfigurationTests {
 
 		TaskRepository taskRepository = this.context.getBean(TaskRepository.class);
 
-		assertNotNull("testRepository should not be null", taskRepository);
+		assertThat(taskRepository).isNotNull();
 
 		Class<?> targetClass = AopProxyUtils.ultimateTargetClass(taskRepository);
 
-		assertEquals(targetClass, SimpleTaskRepository.class);
+		assertThat(targetClass).isEqualTo(SimpleTaskRepository.class);
 	}
 
 
@@ -95,7 +89,7 @@ public class SimpleTaskConfigurationTests {
 
 		TaskExplorer taskExplorer = this.context.getBean(TaskExplorer.class);
 
-		assertThat(taskExplorer.getTaskExecutionCount(), is(equalTo(1l)));
+		assertThat(taskExplorer.getTaskExecutionCount()).isEqualTo(1l);
 	}
 
 	@Test
@@ -117,7 +111,7 @@ public class SimpleTaskConfigurationTests {
 		catch (ApplicationContextException ex) {
 			wasExceptionThrown = true;
 		}
-		assertTrue("Expected ApplicationContextException to be thrown", wasExceptionThrown);
+		assertThat( wasExceptionThrown).isTrue();
 	}
 
 


### PR DESCRIPTION
If a user adds spring-cloud-starter-config to the dependencies it has to add a proxy for the datasource else the Hikari connection pool pukes.

resolves #407