### PR TITLE
Obtain the TaskRepositoryInitializer from the Default Configurer

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskConfiguration.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskConfiguration.java
@@ -115,9 +115,11 @@ public class SimpleTaskConfiguration {
 	public TaskRepositoryInitializer taskRepositoryInitializer() {
 		TaskRepositoryInitializer taskRepositoryInitializer = new TaskRepositoryInitializer();
 
-		if(!CollectionUtils.isEmpty(this.dataSources) && this.dataSources.size() == 1) {
-			DataSource next = this.dataSources.iterator().next();
-			taskRepositoryInitializer.setDataSource(next);
+
+		DataSource initializerDataSource = getDefaultConfigurer().getTaskDataSource();
+
+		if(initializerDataSource != null) {
+			taskRepositoryInitializer.setDataSource(initializerDataSource);
 		}
 
 		return taskRepositoryInitializer;


### PR DESCRIPTION
Get the task database intialization datasource from the default task configurer. Making possible to have more than one datasource defined in the Spring context. 