### PR TITLE
Remove Spring Batch Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,21 +78,6 @@
 				<version>${spring-cloud-deployer-resource-support.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.springframework.batch</groupId>
-				<artifactId>spring-batch-core</artifactId>
-				<version>${spring-batch.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.batch</groupId>
-				<artifactId>spring-batch-infrastructure</artifactId>
-				<version>${spring-batch.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework.batch</groupId>
-				<artifactId>spring-batch-integration</artifactId>
-				<version>${spring-batch.version}</version>
-			</dependency>
-			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-resource-maven</artifactId>
 				<version>${spring-cloud-deployer-resource-maven.version}</version>
@@ -138,7 +123,6 @@
 		<spring-cloud-stream-binder-rabbit.version>2.0.2.RELEASE</spring-cloud-stream-binder-rabbit.version>
 		<spring-cloud-deployer-resource-support.version>1.3.2.RELEASE</spring-cloud-deployer-resource-support.version>
 		<spring-cloud-deployer-resource-maven.version>1.3.2.RELEASE</spring-cloud-deployer-resource-maven.version>
-		<spring-batch.version>4.1.0.RELEASE</spring-batch.version>
 		<commons-logging.version>1.1</commons-logging.version>
 		<java-ee-api.version>8.0</java-ee-api.version>
 		<junit.version>5.3.1</junit.version>


### PR DESCRIPTION
Since Spring Cloud Task depends on Spring Boot, it should obtain the
version of dependencies managed by Spring Boot from Spring Boot.  This
commit removes the explict configuration of Spring Batch's version in
the Spring Cloud Task pom and instead delegates that to Spring Boot.