### PR TITLE
Resolve issue where spring.batch.job.names was not expressed

### DIFF
--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/configuration/TaskBatchProperties.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/configuration/TaskBatchProperties.java
@@ -33,6 +33,7 @@ public class TaskBatchProperties {
 	/**
 	 * Comma-separated list of job names to execute on startup (for instance,
 	 * `job1,job2`). By default, all Jobs found in the context are executed.
+	 * @deprecated use spring.batch.job.names instead of spring.cloud.task.batch.jobNames.
 	 */
 	private String jobNames = "";
 

--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/configuration/TaskJobLauncherAutoConfiguration.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/configuration/TaskJobLauncherAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -49,11 +50,12 @@ public class TaskJobLauncherAutoConfiguration {
 	@Bean
 	public TaskJobLauncherCommandLineRunnerFactoryBean jobLauncherCommandLineRunner(
 			JobLauncher jobLauncher, JobExplorer jobExplorer, List<Job> jobs,
-			JobRegistry jobRegistry, JobRepository jobRepository) {
+			JobRegistry jobRegistry, JobRepository jobRepository,
+			BatchProperties batchProperties) {
 		TaskJobLauncherCommandLineRunnerFactoryBean taskJobLauncherCommandLineRunnerFactoryBean;
 		taskJobLauncherCommandLineRunnerFactoryBean = new TaskJobLauncherCommandLineRunnerFactoryBean(
 				jobLauncher, jobExplorer, jobs, this.properties, jobRegistry,
-				jobRepository);
+				jobRepository, batchProperties);
 
 		return taskJobLauncherCommandLineRunnerFactoryBean;
 	}

--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/configuration/TaskJobLauncherCommandLineRunnerFactoryBean.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/configuration/TaskJobLauncherCommandLineRunnerFactoryBean.java
@@ -24,6 +24,7 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.boot.autoconfigure.batch.BatchProperties;
 import org.springframework.cloud.task.batch.handler.TaskJobLauncherCommandLineRunner;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -55,8 +56,9 @@ public class TaskJobLauncherCommandLineRunnerFactoryBean
 	public TaskJobLauncherCommandLineRunnerFactoryBean(JobLauncher jobLauncher,
 			JobExplorer jobExplorer, List<Job> jobs,
 			TaskBatchProperties taskBatchProperties, JobRegistry jobRegistry,
-			JobRepository jobRepository) {
-		Assert.notNull(taskBatchProperties, "properties must not be null");
+			JobRepository jobRepository, BatchProperties batchProperties) {
+		Assert.notNull(taskBatchProperties, "taskBatchProperties must not be null");
+		Assert.notNull(batchProperties, "batchProperties must not be null");
 		this.jobLauncher = jobLauncher;
 		this.jobExplorer = jobExplorer;
 		Assert.notEmpty(jobs, "jobs must not be null nor empty");
@@ -64,6 +66,12 @@ public class TaskJobLauncherCommandLineRunnerFactoryBean
 		this.jobNames = taskBatchProperties.getJobNames();
 		this.jobRegistry = jobRegistry;
 		this.taskBatchProperties = taskBatchProperties;
+		if (StringUtils.hasText(batchProperties.getJob().getNames())) {
+			this.jobNames = batchProperties.getJob().getNames();
+		}
+		else {
+			this.jobNames = taskBatchProperties.getJobNames();
+		}
 		this.order = taskBatchProperties.getCommandLineRunnerOrder();
 		this.jobRepository = jobRepository;
 	}


### PR DESCRIPTION
when using TaskJobLauncherCommandLineRunner

After research it was determined the only affected property was `spring.batch.job.names`.   Also deprecated `spring.cloud.task.batch.jobNames`
resolves #614