### PR TITLE
Update spring-doc-resources version and highlight

### DIFF
--- a/spring-cloud-task-docs/pom.xml
+++ b/spring-cloud-task-docs/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>io.spring.docresources</groupId>
 			<artifactId>spring-doc-resources</artifactId>
-			<version>0.1.1.RELEASE</version>
+			<version>0.2.0.RELEASE</version>
 			<type>zip</type>
 			<optional>true</optional>
 		</dependency>
@@ -106,7 +106,7 @@
 										<linkcss>true</linkcss>
 										<icons>font</icons>
 										<highlightjsdir>js/highlight</highlightjsdir>
-										<highlightjs-theme>atom-one-dark-reasonable</highlightjs-theme>
+										<highlightjs-theme>github</highlightjs-theme>
 									</attributes>
 								</configuration>
 							</execution>


### PR DESCRIPTION
Update spring-doc-resources and change highlght to github,
to get Damien Vitrac's latest look and feel for the docs.