### PR TITLE
Add new repo method for task execution Ids retrieval

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskExplorer.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskExplorer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,5 +132,12 @@ public interface TaskExplorer {
 	 * @see #getLatestTaskExecutionsByTaskNames(String...)
 	 */
 	TaskExecution getLatestTaskExecutionForTaskName(String taskName);
+
+	/**
+	 * Returns the Set of task execution IDs by the given task name.
+	 * @param taskName the task name
+	 * @return the Set of task execution IDs
+	 */
+	Set<Long> getTaskExecutionIdsByTaskName(String taskName);
 
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/dao/MapTaskExecutionDao.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/dao/MapTaskExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -342,6 +342,17 @@ public class MapTaskExecutionDao implements TaskExecutionDao {
 					"Only expected a single TaskExecution but received "
 							+ taskExecutions.size());
 		}
+	}
+
+	@Override
+	public Set<Long> getTaskExecutionIdsByTaskName(String taskName) {
+		Set<Long> filteredSet = new TreeSet<>();
+		for (Map.Entry<Long, TaskExecution> entry : this.taskExecutions.entrySet()) {
+			if (entry.getValue().getTaskName().equals(taskName)) {
+				filteredSet.add(entry.getValue().getExecutionId());
+			}
+		}
+		return filteredSet;
 	}
 
 	private static class TaskExecutionComparator

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/dao/TaskExecutionDao.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/dao/TaskExecutionDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,5 +231,12 @@ public interface TaskExecutionDao {
 	 * @see #getLatestTaskExecutionsByTaskNames(String...)
 	 */
 	TaskExecution getLatestTaskExecutionForTaskName(String taskName);
+
+	/**
+	 * Returns the Set of task execution IDs by the given task name.
+	 * @param taskName the task name
+	 * @return the Set of task execution IDs
+	 */
+	Set<Long> getTaskExecutionIdsByTaskName(String taskName);
 
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorer.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,11 @@ public class SimpleTaskExplorer implements TaskExplorer {
 	@Override
 	public TaskExecution getLatestTaskExecutionForTaskName(String taskName) {
 		return this.taskExecutionDao.getLatestTaskExecutionForTaskName(taskName);
+	}
+
+	@Override
+	public Set<Long> getTaskExecutionIdsByTaskName(String taskName) {
+		return this.taskExecutionDao.getTaskExecutionIdsByTaskName(taskName);
 	}
 
 }

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/dao/JdbcTaskExecutionDaoTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/dao/JdbcTaskExecutionDaoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.sql.DataSource;
@@ -203,6 +205,19 @@ public class JdbcTaskExecutionDaoTests extends BaseTaskExecutionDaoTestCases {
 		TestVerifierUtils.verifyTaskExecution(expectedTaskExecution,
 				TestDBUtils.getTaskExecutionFromDB(this.dataSource,
 						expectedTaskExecution.getExecutionId()));
+	}
+
+	@Test
+	@DirtiesContext
+	public void testGetTaskExecutionIdsByTaskName() {
+		String taskName = UUID.randomUUID().toString();
+		List<TaskExecution> taskExecutions = TestVerifierUtils
+				.createSampleTaskExecutions(taskName, 4);
+		for (TaskExecution taskExecution : taskExecutions) {
+			this.repository.createTaskExecution(taskExecution);
+		}
+		Set<Long> taskExecutionIds = this.dao.getTaskExecutionIdsByTaskName(taskName);
+		assertThat(taskExecutionIds.size()).isEqualTo(4);
 	}
 
 	private TaskExecution initializeTaskExecutionWithExternalExecutionId() {

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/dao/MapTaskExecutionDaoTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/dao/MapTaskExecutionDaoTests.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.cloud.task.util.TestVerifierUtils;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -175,6 +176,17 @@ public class MapTaskExecutionDaoTests extends BaseTaskExecutionDaoTestCases {
 				expectedTaskExecution.getArguments(), "BAR");
 		TestVerifierUtils.verifyTaskExecution(expectedTaskExecution,
 				taskExecutionMap.get(expectedTaskExecution.getExecutionId()));
+	}
+
+	@Test
+	@DirtiesContext
+	public void testGetTaskExecutionIdsByTaskName() {
+		String taskName = UUID.randomUUID().toString();
+		for (int i = 0; i < 4; i++) {
+			this.dao.createTaskExecution(taskName, null, new ArrayList<>(0), null);
+		}
+		Set<Long> taskExecutionIds = this.dao.getTaskExecutionIdsByTaskName(taskName);
+		assertThat(taskExecutionIds.size()).isEqualTo(4);
 	}
 
 	private TaskExecution initializeTaskExecutionWithExternalExecutionId() {

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/support/SimpleTaskExplorerTests.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
@@ -329,6 +330,15 @@ public class SimpleTaskExplorerTests {
 		}
 	}
 
+	@Test
+	public void getTaskExecutionIdsByTaskName() {
+		String taskName = UUID.randomUUID().toString();
+		createAndSaveSampleTaskExecutions(taskName, 4);
+		Set<Long> taskExecutionIdsFromRepo = this.taskExplorer
+				.getTaskExecutionIdsByTaskName(taskName);
+		assertThat(taskExecutionIdsFromRepo.size()).isEqualTo(4);
+	}
+
 	private void verifyPageResults(Pageable pageable, int totalNumberOfExecs) {
 		Map<Long, TaskExecution> expectedResults = createSampleDataSet(
 				totalNumberOfExecs);
@@ -379,6 +389,16 @@ public class SimpleTaskExplorerTests {
 				.isEqualTo(pagesExpected);
 		assertThat(elementCount).as("Elements processed did not equal expected,")
 				.isEqualTo(totalNumberOfExecs);
+	}
+
+	private List<TaskExecution> createAndSaveSampleTaskExecutions(String taskName,
+			int size) {
+		List<TaskExecution> taskExecutions = TestVerifierUtils
+				.createSampleTaskExecutions(taskName, size);
+		for (TaskExecution taskExecution : taskExecutions) {
+			this.taskRepository.createTaskExecution(taskExecution);
+		}
+		return taskExecutions;
 	}
 
 	private TaskExecution createAndSaveTaskExecution(int i) {

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/util/TestVerifierUtils.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/util/TestVerifierUtils.java
@@ -131,6 +131,30 @@ public final class TestVerifierUtils {
 	}
 
 	/**
+	 * Creates multiple task executions for a given task name
+	 * @param taskName the task name for the task executions
+	 * @param numExecutions the number of task executions
+	 * @return list of TaskExecutions.
+	 */
+	public static List<TaskExecution> createSampleTaskExecutions(String taskName,
+			int numExecutions) {
+		Date startTime = new Date();
+		String externalExecutionId = UUID.randomUUID().toString();
+		Random randomGenerator = new Random();
+		List<TaskExecution> taskExecutions = new ArrayList<>();
+		for (int i = 0; i < numExecutions; i++) {
+			long executionId = randomGenerator.nextLong();
+			List<String> args = new ArrayList<>(ARG_SIZE);
+			for (int j = 0; j < ARG_SIZE; j++) {
+				args.add(UUID.randomUUID().toString());
+			}
+			taskExecutions.add(new TaskExecution(executionId, null, taskName, startTime,
+					null, null, args, null, externalExecutionId));
+		}
+		return taskExecutions;
+	}
+
+	/**
 	 * Verifies that all the fields in between the expected and actual are the same.
 	 * @param expectedTaskExecution The expected value for the task execution.
 	 * @param actualTaskExecution The actual value for the task execution.


### PR DESCRIPTION
 - It seems convenient to have a new repo method to get the set of task execution Ids by the given task name.
   This also simplifies multiple repository method invocations/further processing to achieve the same.

 - Add `getTaskExecutionIdsByTaskName` method into TaskExplorer and TaskExecutionDao

 - Implement the new methods and udpate the tests

Resolves #666