### PR TITLE
Added missing `@EnableTask` annotation

### DIFF
--- a/spring-cloud-task-docs/src/main/asciidoc/getting-started.adoc
+++ b/spring-cloud-task-docs/src/main/asciidoc/getting-started.adoc
@@ -80,6 +80,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
+@EnableTask
 public class HelloworldApplication {
 
 	@Bean


### PR DESCRIPTION
Following the documentation (using Spring Boot 2.3.0 and Spring Cloud Hoxton.SR5) does not yield the described output if that annotation is missing. I saw it being used in several videos of M. Minella, so I think it is a glitch.
Adding the annotation to my code showed the log output where `TaskExecution` is created and updated in the repository. Without the annotation that does not show (and probably does not happen either).