### PR TITLE
Enabling custom `TaskNameResolver` implementation

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskAutoConfiguration.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskAutoConfiguration.java
@@ -100,6 +100,7 @@ public class SimpleTaskAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	public TaskNameResolver taskNameResolver() {
 		return new SimpleTaskNameResolver();
 	}


### PR DESCRIPTION
The [Spring Cloud Task documentation](https://docs.spring.io/spring-cloud-task/docs/current/reference/#features-task-name) suggests that an application can influence the naming of tasks - by virtue of configuration but also by providing its own implementation of `TaskNameResolver`. The latter is not the case, since `SimpleTaskAutoConfiguration` declares the `TaskNameResolver` bean without `@ConditionalOnMissingBean`.