### PR TITLE
Task tags assigned to all metrics sent by the app

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/MetricsAutoConfiguration.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/MetricsAutoConfiguration.java
@@ -47,7 +47,7 @@ import org.springframework.core.env.Environment;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(Timed.class)
 @AutoConfigureBefore(name = {
-		"org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration" })
+		"org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration" })
 public class MetricsAutoConfiguration {
 
 	@Bean


### PR DESCRIPTION
 - Ensure that Task's org.springframework.cloud.task.configurationorg.springframework.cloud.task.configuration.MetricsAutoConfiguration is configured Before org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration (that in turn is configured Before the CompositeMeterRegistryAutoConfiguration).

 Resolves #691