### PR TITLE
Updated generics on single step batch job starter

### DIFF
--- a/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/SingleStepJobAutoConfiguration.java
+++ b/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/SingleStepJobAutoConfiguration.java
@@ -55,7 +55,7 @@ public class SingleStepJobAutoConfiguration {
 	private SingleStepJobProperties properties;
 
 	@Autowired(required = false)
-	private ItemProcessor<Map<Object, Object>, Map<Object, Object>> itemProcessor;
+	private ItemProcessor<Map<String, Object>, Map<String, Object>> itemProcessor;
 
 	public SingleStepJobAutoConfiguration(JobBuilderFactory jobBuilderFactory,
 			StepBuilderFactory stepBuilderFactory, SingleStepJobProperties properties,
@@ -79,12 +79,12 @@ public class SingleStepJobAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(prefix = "spring.batch.job", name = "jobName")
-	public Job job(ItemReader<Map<Object, Object>> itemReader,
-			ItemWriter<Map<Object, Object>> itemWriter) {
+	public Job job(ItemReader<Map<String, Object>> itemReader,
+			ItemWriter<Map<String, Object>> itemWriter) {
 
-		SimpleStepBuilder<Map<Object, Object>, Map<Object, Object>> stepBuilder = this.stepBuilderFactory
+		SimpleStepBuilder<Map<String, Object>, Map<String, Object>> stepBuilder = this.stepBuilderFactory
 				.get(this.properties.getStepName())
-				.<Map<Object, Object>, Map<Object, Object>>chunk(
+				.<Map<String, Object>, Map<String, Object>>chunk(
 						this.properties.getChunkSize())
 				.reader(itemReader);
 

--- a/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/flatfile/FlatFileItemReaderAutoConfiguration.java
+++ b/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/flatfile/FlatFileItemReaderAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.task.batch.autoconfigure.flatfile;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.batch.item.file.FlatFileItemReader;
@@ -53,10 +54,10 @@ public class FlatFileItemReaderAutoConfiguration {
 	private LineTokenizer lineTokenizer;
 
 	@Autowired(required = false)
-	private FieldSetMapper<Map<Object, Object>> fieldSetMapper;
+	private FieldSetMapper<Map<String, Object>> fieldSetMapper;
 
 	@Autowired(required = false)
-	private LineMapper<Map<Object, Object>> lineMapper;
+	private LineMapper<Map<String, Object>> lineMapper;
 
 	@Autowired(required = false)
 	private LineCallbackHandler skippedLinesCallback;
@@ -71,8 +72,8 @@ public class FlatFileItemReaderAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(prefix = "spring.batch.job.flatfilereader", name = "name")
-	public FlatFileItemReader<Map<Object, Object>> itemReader() {
-		FlatFileItemReaderBuilder<Map<Object, Object>> mapFlatFileItemReaderBuilder = new FlatFileItemReaderBuilder<Map<Object, Object>>()
+	public FlatFileItemReader<Map<String, Object>> itemReader() {
+		FlatFileItemReaderBuilder<Map<String, Object>> mapFlatFileItemReaderBuilder = new FlatFileItemReaderBuilder<Map<String, Object>>()
 				.name(this.properties.getName()).resource(this.properties.getResource())
 				.saveState(this.properties.isSaveState())
 				.maxItemCount(this.properties.getMaxItemCount())
@@ -127,13 +128,13 @@ public class FlatFileItemReaderAutoConfiguration {
 
 	/**
 	 * A {@link FieldSetMapper} that takes a {@code FieldSet} and returns the
-	 * {@code Map<Object, Object>} of its contents.
+	 * {@code Map<String, Object>} of its contents.
 	 */
-	public static class MapFieldSetMapper implements FieldSetMapper<Map<Object, Object>> {
+	public static class MapFieldSetMapper implements FieldSetMapper<Map<String, Object>> {
 
 		@Override
-		public Map<Object, Object> mapFieldSet(FieldSet fieldSet) {
-			return fieldSet.getProperties();
+		public Map<String, Object> mapFieldSet(FieldSet fieldSet) {
+			return new HashMap<String, Object>((Map) fieldSet.getProperties());
 		}
 
 	}

--- a/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/flatfile/FlatFileItemWriterAutoConfiguration.java
+++ b/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/flatfile/FlatFileItemWriterAutoConfiguration.java
@@ -49,10 +49,10 @@ public class FlatFileItemWriterAutoConfiguration {
 	private FlatFileItemWriterProperties properties;
 
 	@Autowired(required = false)
-	private LineAggregator<Map<Object, Object>> lineAggregator;
+	private LineAggregator<Map<String, Object>> lineAggregator;
 
 	@Autowired(required = false)
-	private FieldExtractor<Map<Object, Object>> fieldExtractor;
+	private FieldExtractor<Map<String, Object>> fieldExtractor;
 
 	@Autowired(required = false)
 	private FlatFileHeaderCallback headerCallback;
@@ -67,7 +67,7 @@ public class FlatFileItemWriterAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(prefix = "spring.batch.job.flatfilewriter", name = "name")
-	public FlatFileItemWriter<Map<Object, Object>> itemWriter() {
+	public FlatFileItemWriter<Map<String, Object>> itemWriter() {
 
 		if (this.properties.isDelimited() && this.properties.isFormatted()) {
 			throw new IllegalStateException(
@@ -80,7 +80,7 @@ public class FlatFileItemWriterAutoConfiguration {
 					+ "output is not formatted or delimited");
 		}
 
-		FlatFileItemWriterBuilder<Map<Object, Object>> builder = new FlatFileItemWriterBuilder<Map<Object, Object>>()
+		FlatFileItemWriterBuilder<Map<String, Object>> builder = new FlatFileItemWriterBuilder<Map<String, Object>>()
 				.name(this.properties.getName()).resource(this.properties.getResource())
 				.append(this.properties.isAppend())
 				.encoding(this.properties.getEncoding())
@@ -93,7 +93,7 @@ public class FlatFileItemWriterAutoConfiguration {
 				.headerCallback(this.headerCallback).footerCallback(this.footerCallback);
 
 		if (this.properties.isDelimited()) {
-			FlatFileItemWriterBuilder.DelimitedBuilder<Map<Object, Object>> delimitedBuilder = builder
+			FlatFileItemWriterBuilder.DelimitedBuilder<Map<String, Object>> delimitedBuilder = builder
 					.delimited().delimiter(this.properties.getDelimiter());
 
 			if (this.fieldExtractor != null) {
@@ -105,7 +105,7 @@ public class FlatFileItemWriterAutoConfiguration {
 			}
 		}
 		else if (this.properties.isFormatted()) {
-			FlatFileItemWriterBuilder.FormattedBuilder<Map<Object, Object>> formattedBuilder = builder
+			FlatFileItemWriterBuilder.FormattedBuilder<Map<String, Object>> formattedBuilder = builder
 					.formatted().format(this.properties.getFormat())
 					.locale(this.properties.getLocale())
 					.maximumLength(this.properties.getMaximumLength())
@@ -127,10 +127,10 @@ public class FlatFileItemWriterAutoConfiguration {
 	}
 
 	/**
-	 * A {@code FieldExtractor} that converts a {@code Map<Object, Object>} to the ordered
+	 * A {@code FieldExtractor} that converts a {@code Map<String, Object>} to the ordered
 	 * {@code Object[]} required to populate an output record.
 	 */
-	public static class MapFieldExtractor implements FieldExtractor<Map<Object, Object>> {
+	public static class MapFieldExtractor implements FieldExtractor<Map<String, Object>> {
 
 		private String[] names;
 
@@ -139,7 +139,7 @@ public class FlatFileItemWriterAutoConfiguration {
 		}
 
 		@Override
-		public Object[] extract(Map<Object, Object> item) {
+		public Object[] extract(Map<String, Object> item) {
 
 			List<Object> fields = new ArrayList<>(item.size());
 

--- a/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JdbcCursorItemReaderAutoConfiguration.java
+++ b/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JdbcCursorItemReaderAutoConfiguration.java
@@ -54,7 +54,7 @@ public class JdbcCursorItemReaderAutoConfiguration {
 	private PreparedStatementSetter preparedStatementSetter;
 
 	@Autowired(required = false)
-	private RowMapper<Map<Object, Object>> rowMapper;
+	private RowMapper<Map<String, Object>> rowMapper;
 
 	public JdbcCursorItemReaderAutoConfiguration(
 			JdbcCursorItemReaderProperties properties, DataSource dataSource) {
@@ -64,8 +64,8 @@ public class JdbcCursorItemReaderAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public JdbcCursorItemReader<Map<Object, Object>> itemReader() {
-		return new JdbcCursorItemReaderBuilder<Map<Object, Object>>()
+	public JdbcCursorItemReader<Map<String, Object>> itemReader() {
+		return new JdbcCursorItemReaderBuilder<Map<String, Object>>()
 				.name(this.properties.getName())
 				.currentItemCount(this.properties.getCurrentItemCount())
 				.dataSource(this.dataSource)
@@ -86,15 +86,15 @@ public class JdbcCursorItemReaderAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public RowMapper<Map<Object, Object>> rowMapper() {
+	public RowMapper<Map<String, Object>> rowMapper() {
 		return new MapRowMapper();
 	}
 
-	public static class MapRowMapper implements RowMapper<Map<Object, Object>> {
+	public static class MapRowMapper implements RowMapper<Map<String, Object>> {
 
 		@Override
-		public Map<Object, Object> mapRow(ResultSet rs, int rowNum) throws SQLException {
-			Map<Object, Object> item = new HashMap<>(rs.getMetaData().getColumnCount());
+		public Map<String, Object> mapRow(ResultSet rs, int rowNum) throws SQLException {
+			Map<String, Object> item = new HashMap<>(rs.getMetaData().getColumnCount());
 
 			for (int i = 1; i <= rs.getMetaData().getColumnCount(); i++) {
 				item.put(rs.getMetaData().getColumnName(i), rs.getObject(i));

--- a/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JdbcItemWriterAutoConfiguration.java
+++ b/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JdbcItemWriterAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Configuration;
  * Autconfiguration for a {@code JdbcBatchItemWriter}.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  * @since 2.3
  */
 @Configuration
@@ -63,9 +64,9 @@ public class JdbcItemWriterAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(prefix = "spring.batch.job.jdbcwriter", name = "name")
-	public ItemWriter<Map<Object, Object>> itemWriter() {
+	public ItemWriter<Map<String, Object>> itemWriter() {
 
-		JdbcBatchItemWriterBuilder<Map<Object, Object>> jdbcBatchItemWriterBuilder = new JdbcBatchItemWriterBuilder<Map<Object, Object>>()
+		JdbcBatchItemWriterBuilder<Map<String, Object>> jdbcBatchItemWriterBuilder = new JdbcBatchItemWriterBuilder<Map<String, Object>>()
 				.dataSource(this.dataSource).sql(this.properties.getSql());
 		if (this.itemPreparedStatementSetter != null) {
 			jdbcBatchItemWriterBuilder

--- a/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/kafka/KafkaItemReaderAutoConfiguration.java
+++ b/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/kafka/KafkaItemReaderAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.util.StringUtils;
  * AutoConfiguration for a {@code KafkaItemReader}.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  * @since 2.3
  */
 @Configuration
@@ -52,7 +53,7 @@ public class KafkaItemReaderAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnProperty(prefix = "spring.batch.job.kafkaitemreader", name = "name")
-	public KafkaItemReader<Object, Map<Object, Object>> kafkaItemReader(
+	public KafkaItemReader<Object, Map<String, Object>> kafkaItemReader(
 			KafkaItemReaderProperties kafkaItemReaderProperties) {
 		Properties consumerProperties = new Properties();
 		consumerProperties.putAll(this.kafkaProperties.getConsumer().buildProperties());
@@ -62,7 +63,7 @@ public class KafkaItemReaderAutoConfiguration {
 			kafkaItemReaderProperties.setPartitions(new ArrayList<>(1));
 			kafkaItemReaderProperties.getPartitions().add(0);
 		}
-		return new KafkaItemReaderBuilder<Object, Map<Object, Object>>()
+		return new KafkaItemReaderBuilder<Object, Map<String, Object>>()
 				.partitions(kafkaItemReaderProperties.getPartitions())
 				.consumerProperties(consumerProperties)
 				.name(kafkaItemReaderProperties.getName())

--- a/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/rabbit/AmqpItemReaderAutoConfiguration.java
+++ b/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/rabbit/AmqpItemReaderAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Configuration;
  * Autconfiguration for a {@code AmqpItemReader}.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  * @since 2.3
  */
 @Configuration
@@ -54,9 +55,9 @@ public class AmqpItemReaderAutoConfiguration {
 	}
 
 	@Bean
-	public AmqpItemReader<Map<Object, Object>> amqpItemReader(AmqpTemplate amqpTemplate,
+	public AmqpItemReader<Map<String, Object>> amqpItemReader(AmqpTemplate amqpTemplate,
 			@Autowired(required = false) Class itemType) {
-		AmqpItemReaderBuilder<Map<Object, Object>> builder = new AmqpItemReaderBuilder<Map<Object, Object>>()
+		AmqpItemReaderBuilder<Map<String, Object>> builder = new AmqpItemReaderBuilder<Map<String, Object>>()
 				.amqpTemplate(amqpTemplate);
 		if (itemType != null) {
 			builder.itemType(itemType);

--- a/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/rabbit/AmqpItemWriterAutoConfiguration.java
+++ b/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/rabbit/AmqpItemWriterAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Configuration;
  * Autconfiguration for a {@code AmqpItemWriter}.
  *
  * @author Glenn Renfro
+ * @author Michael Minella
  * @since 2.3
  */
 @Configuration
@@ -44,8 +45,8 @@ import org.springframework.context.annotation.Configuration;
 public class AmqpItemWriterAutoConfiguration {
 
 	@Bean
-	public AmqpItemWriter<Map<Object, Object>> amqpItemWriter(AmqpTemplate amqpTemplate) {
-		return new AmqpItemWriterBuilder<Map<Object, Object>>().amqpTemplate(amqpTemplate)
+	public AmqpItemWriter<Map<String, Object>> amqpItemWriter(AmqpTemplate amqpTemplate) {
+		return new AmqpItemWriterBuilder<Map<String, Object>>().amqpTemplate(amqpTemplate)
 				.build();
 	}
 

--- a/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/SingleStepJobAutoConfigurationTests.java
+++ b/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/SingleStepJobAutoConfigurationTests.java
@@ -127,7 +127,7 @@ public class SingleStepJobAutoConfigurationTests {
 				Thread.sleep(1000);
 			}
 
-			List<Map<Object, Object>> writtenItems = itemWriter.getWrittenItems();
+			List<Map<String, Object>> writtenItems = itemWriter.getWrittenItems();
 
 			assertThat(writtenItems.size()).isEqualTo(3);
 
@@ -142,8 +142,8 @@ public class SingleStepJobAutoConfigurationTests {
 	public static class SimpleConfiguration {
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemReader() {
-			List<Map<Object, Object>> items = new ArrayList<>(3);
+		public ListItemReader<Map<String, Object>> itemReader() {
+			List<Map<String, Object>> items = new ArrayList<>(3);
 
 			items.add(Collections.singletonMap("item", "foo"));
 			items.add(Collections.singletonMap("item", "bar"));
@@ -153,7 +153,7 @@ public class SingleStepJobAutoConfigurationTests {
 		}
 
 		@Bean
-		public ListItemWriter<Map<Object, Object>> itemWriter() {
+		public ListItemWriter<Map<String, Object>> itemWriter() {
 			return new ListItemWriter<>();
 		}
 

--- a/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/flatfile/FlatFileItemReaderAutoConfigurationTests.java
+++ b/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/flatfile/FlatFileItemReaderAutoConfigurationTests.java
@@ -307,7 +307,7 @@ public class FlatFileItemReaderAutoConfigurationTests {
 				Thread.sleep(1000);
 			}
 
-			List<Map<Object, Object>> writtenItems = itemWriter.getWrittenItems();
+			List<Map<String, Object>> writtenItems = itemWriter.getWrittenItems();
 
 			assertThat(writtenItems.size()).isEqualTo(1);
 			assertThat(writtenItems.get(0).get("one")).isEqualTo("1 2 3");
@@ -329,7 +329,7 @@ public class FlatFileItemReaderAutoConfigurationTests {
 		private FlatFileItemReader itemReader;
 
 		@Bean
-		public ListItemWriter<Map> itemWriter() {
+		public ListItemWriter<Map<String, Object>> itemWriter() {
 			return new ListItemWriter<>();
 		}
 
@@ -341,8 +341,8 @@ public class FlatFileItemReaderAutoConfigurationTests {
 		}
 
 		@Bean
-		public FieldSetMapper<Map<Object, Object>> fieldSetMapper() {
-			return fieldSet -> fieldSet.getProperties();
+		public FieldSetMapper<Map<String, Object>> fieldSetMapper() {
+			return fieldSet -> new HashMap<String, Object>((Map) fieldSet.getProperties());
 		}
 
 	}
@@ -352,7 +352,7 @@ public class FlatFileItemReaderAutoConfigurationTests {
 	public static class JobConfiguration {
 
 		@Bean
-		public ListItemWriter<Map> itemWriter() {
+		public ListItemWriter<Map<String, Object>> itemWriter() {
 			return new ListItemWriter<>();
 		}
 
@@ -397,7 +397,7 @@ public class FlatFileItemReaderAutoConfigurationTests {
 		}
 
 		@Bean
-		public ListItemWriter<Map> itemWriter() {
+		public ListItemWriter<Map<String, Object>> itemWriter() {
 			return new ListItemWriter<>();
 		}
 
@@ -408,9 +408,9 @@ public class FlatFileItemReaderAutoConfigurationTests {
 	public static class CustomLineMapperConfiguration {
 
 		@Bean
-		public LineMapper<Map<Object, Object>> lineMapper() {
+		public LineMapper<Map<String, Object>> lineMapper() {
 			return (line, lineNumber) -> {
-				Map<Object, Object> item = new HashMap<>(1);
+				Map<String, Object> item = new HashMap<>(1);
 
 				item.put("line", line);
 				item.put("lineNumber", lineNumber);
@@ -420,7 +420,7 @@ public class FlatFileItemReaderAutoConfigurationTests {
 		}
 
 		@Bean
-		public ListItemWriter<Map> itemWriter() {
+		public ListItemWriter<Map<String, Object>> itemWriter() {
 			return new ListItemWriter<>();
 		}
 

--- a/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/flatfile/FlatFileItemWriterAutoConfigurationTests.java
+++ b/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/flatfile/FlatFileItemWriterAutoConfigurationTests.java
@@ -395,9 +395,9 @@ public class FlatFileItemWriterAutoConfigurationTests {
 	public static class DelimitedJobConfiguration {
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemReader() {
+		public ListItemReader<Map<String, Object>> itemReader() {
 
-			List<Map<Object, Object>> items = new ArrayList<>(3);
+			List<Map<String, Object>> items = new ArrayList<>(3);
 
 			items.add(Collections.singletonMap("item", "foo"));
 			items.add(Collections.singletonMap("item", "bar"));
@@ -413,9 +413,9 @@ public class FlatFileItemWriterAutoConfigurationTests {
 	public static class LineAggregatorConfiguration {
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemReader() {
+		public ListItemReader<Map<String, Object>> itemReader() {
 
-			List<Map<Object, Object>> items = new ArrayList<>(3);
+			List<Map<String, Object>> items = new ArrayList<>(3);
 
 			items.add(Collections.singletonMap("item", "foo"));
 			items.add(Collections.singletonMap("item", "bar"));
@@ -425,7 +425,7 @@ public class FlatFileItemWriterAutoConfigurationTests {
 		}
 
 		@Bean
-		public LineAggregator<Map<Object, Object>> lineAggregator() {
+		public LineAggregator<Map<String, Object>> lineAggregator() {
 			return new PassThroughLineAggregator<>();
 		}
 
@@ -436,9 +436,9 @@ public class FlatFileItemWriterAutoConfigurationTests {
 	public static class HeaderFooterConfiguration {
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemReader() {
+		public ListItemReader<Map<String, Object>> itemReader() {
 
-			List<Map<Object, Object>> items = new ArrayList<>(3);
+			List<Map<String, Object>> items = new ArrayList<>(3);
 
 			items.add(Collections.singletonMap("item", "foo"));
 			items.add(Collections.singletonMap("item", "bar"));
@@ -464,9 +464,9 @@ public class FlatFileItemWriterAutoConfigurationTests {
 	public static class FieldExtractorConfiguration {
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemReader() {
+		public ListItemReader<Map<String, Object>> itemReader() {
 
-			List<Map<Object, Object>> items = new ArrayList<>(3);
+			List<Map<String, Object>> items = new ArrayList<>(3);
 
 			items.add(Collections.singletonMap("item", "foo"));
 			items.add(Collections.singletonMap("item", "bar"));
@@ -476,7 +476,7 @@ public class FlatFileItemWriterAutoConfigurationTests {
 		}
 
 		@Bean
-		public FieldExtractor<Map<Object, Object>> lineAggregator() {
+		public FieldExtractor<Map<String, Object>> lineAggregator() {
 			return item -> {
 				List<String> fields = new ArrayList<>(1);
 
@@ -492,9 +492,9 @@ public class FlatFileItemWriterAutoConfigurationTests {
 	public static class FormattedJobConfiguration {
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemReader() {
+		public ListItemReader<Map<String, Object>> itemReader() {
 
-			List<Map<Object, Object>> items = new ArrayList<>(3);
+			List<Map<String, Object>> items = new ArrayList<>(3);
 
 			items.add(Collections.singletonMap("item", "foo"));
 			items.add(Collections.singletonMap("item", "bar"));
@@ -510,7 +510,7 @@ public class FlatFileItemWriterAutoConfigurationTests {
 	public static class FormattedFieldExtractorJobConfiguration {
 
 		@Bean
-		public FieldExtractor<Map<Object, Object>> lineAggregator() {
+		public FieldExtractor<Map<String, Object>> lineAggregator() {
 			return item -> {
 				List<String> fields = new ArrayList<>(1);
 
@@ -520,9 +520,9 @@ public class FlatFileItemWriterAutoConfigurationTests {
 		}
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemReader() {
+		public ListItemReader<Map<String, Object>> itemReader() {
 
-			List<Map<Object, Object>> items = new ArrayList<>(3);
+			List<Map<String, Object>> items = new ArrayList<>(3);
 
 			items.add(Collections.singletonMap("item", "foo"));
 			items.add(Collections.singletonMap("item", "bar"));

--- a/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JdbcCursorItemReaderAutoConfigurationTests.java
+++ b/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JdbcCursorItemReaderAutoConfigurationTests.java
@@ -116,7 +116,7 @@ public class JdbcCursorItemReaderAutoConfigurationTests {
 				Thread.sleep(1000);
 			}
 
-			List<Map<Object, Object>> items = context.getBean(ListItemWriter.class)
+			List<Map<String, Object>> items = context.getBean(ListItemWriter.class)
 					.getWrittenItems();
 
 			assertThat(items.size()).isEqualTo(3);
@@ -154,7 +154,7 @@ public class JdbcCursorItemReaderAutoConfigurationTests {
 				Thread.sleep(1000);
 			}
 
-			List<Map<Object, Object>> items = context.getBean(ListItemWriter.class)
+			List<Map<String, Object>> items = context.getBean(ListItemWriter.class)
 					.getWrittenItems();
 
 			assertThat(items.size()).isEqualTo(3);
@@ -191,7 +191,7 @@ public class JdbcCursorItemReaderAutoConfigurationTests {
 
 		applicationContextRunner.run((context) -> {
 
-			JdbcCursorItemReader<Map<Object, Object>> itemReader = context
+			JdbcCursorItemReader<Map<String, Object>> itemReader = context
 					.getBean(JdbcCursorItemReader.class);
 
 			validateBean(itemReader);
@@ -340,7 +340,7 @@ public class JdbcCursorItemReaderAutoConfigurationTests {
 	public static class BaseConfiguration {
 
 		@Bean
-		public ListItemWriter<Map<Object, Object>> itemWriter() {
+		public ListItemWriter<Map<String, Object>> itemWriter() {
 			return new ListItemWriter<>();
 		}
 
@@ -351,9 +351,9 @@ public class JdbcCursorItemReaderAutoConfigurationTests {
 	public static class RowMapperConfiguration {
 
 		@Bean
-		public RowMapper<Map<Object, Object>> rowMapper() {
+		public RowMapper<Map<String, Object>> rowMapper() {
 			return (rs, rowNum) -> {
-				Map<Object, Object> item = new HashMap<>();
+				Map<String, Object> item = new HashMap<>();
 
 				item.put("item", rs.getString("item_name"));
 
@@ -362,7 +362,7 @@ public class JdbcCursorItemReaderAutoConfigurationTests {
 		}
 
 		@Bean
-		public ListItemWriter<Map<Object, Object>> itemWriter() {
+		public ListItemWriter<Map<String, Object>> itemWriter() {
 			return new ListItemWriter<>();
 		}
 

--- a/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JdbcItemWriterAutoConfigurationTests.java
+++ b/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JdbcItemWriterAutoConfigurationTests.java
@@ -239,9 +239,9 @@ public class JdbcItemWriterAutoConfigurationTests {
 	public static class DelimitedJobConfiguration {
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemReader() {
+		public ListItemReader<Map<String, Object>> itemReader() {
 
-			List<Map<Object, Object>> items = new ArrayList<>(3);
+			List<Map<String, Object>> items = new ArrayList<>(3);
 
 			items.add(Collections.singletonMap("item_name", "foo"));
 			items.add(Collections.singletonMap("item_name", "bar"));
@@ -257,9 +257,9 @@ public class JdbcItemWriterAutoConfigurationTests {
 	public static class DelimitedDifferentKeyNameJobConfiguration {
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemReader() {
+		public ListItemReader<Map<String, Object>> itemReader() {
 
-			List<Map<Object, Object>> items = new ArrayList<>(3);
+			List<Map<String, Object>> items = new ArrayList<>(3);
 
 			items.add(Collections.singletonMap("item_foo", "foo"));
 			items.add(Collections.singletonMap("item_foo", "bar"));
@@ -275,7 +275,7 @@ public class JdbcItemWriterAutoConfigurationTests {
 	public static class CustomSqlParameterSourceProviderConfiguration {
 
 		@Bean
-		public ItemSqlParameterSourceProvider<Map<Object, Object>> itemSqlParameterSourceProvider() {
+		public ItemSqlParameterSourceProvider<Map<String, Object>> itemSqlParameterSourceProvider() {
 			return item -> new MapSqlParameterSource(new HashMap<String, Object>() {
 				{
 					put("item_name", item.get("item_foo"));

--- a/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/kafka/KafkaItemReaderAutoConfigurationTests.java
+++ b/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/kafka/KafkaItemReaderAutoConfigurationTests.java
@@ -102,7 +102,7 @@ public class KafkaItemReaderAutoConfigurationTests {
 				Thread.sleep(1000);
 			}
 
-			List<Map<Object, Object>> writtenItems = itemWriter.getWrittenItems();
+			List<Map<String, Object>> writtenItems = itemWriter.getWrittenItems();
 
 			assertThat(writtenItems.size()).isEqualTo(4);
 			assertThat(writtenItems.get(0).get("first_name")).isEqualTo("jane");
@@ -197,7 +197,7 @@ public class KafkaItemReaderAutoConfigurationTests {
 	}
 
 	private void basicValidation(ListItemWriter itemWriter) {
-		List<Map<Object, Object>> writtenItems = itemWriter.getWrittenItems();
+		List<Map<String, Object>> writtenItems = itemWriter.getWrittenItems();
 		assertThat(writtenItems.size()).isEqualTo(4);
 		List<Object> results = new ArrayList<>();
 		for (int i = 0; i < 4; i++) {
@@ -212,7 +212,7 @@ public class KafkaItemReaderAutoConfigurationTests {
 				KafkaTestUtils.producerProps(embeddedKafkaBroker));
 		Producer<String, Object> producer = new DefaultKafkaProducerFactory<>(configps,
 				new StringSerializer(), new JsonSerializer<>()).createProducer();
-		Map<Object, Object> testMap = new HashMap<>();
+		Map<String, Object> testMap = new HashMap<>();
 		testMap.put("first_name", "jane");
 		producer.send(new ProducerRecord<>(topic, "my-aggregate-id", testMap));
 		testMap = new HashMap<>();
@@ -232,7 +232,7 @@ public class KafkaItemReaderAutoConfigurationTests {
 	@Configuration
 	public static class CustomMappingConfiguration {
 		@Bean
-		public ListItemWriter<Map<Object, Object>> itemWriter() {
+		public ListItemWriter<Map<String, Object>> itemWriter() {
 			return new ListItemWriter<>();
 		}
 	}

--- a/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/kafka/KafkaItemWriterTests.java
+++ b/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/kafka/KafkaItemWriterTests.java
@@ -95,9 +95,9 @@ public class KafkaItemWriterTests {
 		ConsumerRecords<String, Object> consumerRecords = KafkaTestUtils
 				.getRecords(consumer);
 		assertThat(consumerRecords.count()).isEqualTo(5);
-		List<Map<Object, Object>> result = new ArrayList<>();
+		List<Map<String, Object>> result = new ArrayList<>();
 		consumerRecords.forEach(cs -> {
-			result.add((Map<Object, Object>) cs.value());
+			result.add((Map<String, Object>) cs.value());
 		});
 		List<String> firstNames = new ArrayList<>();
 		result.forEach(s -> firstNames.add((String) s.get("first_name")));
@@ -125,8 +125,8 @@ public class KafkaItemWriterTests {
 	public static class CustomMappingConfiguration {
 
 		@Bean
-		public ListItemReader<Map<Object, Object>> itemWriter() {
-			List<Map<Object, Object>> list = new ArrayList<>(5);
+		public ListItemReader<Map<String, Object>> itemReader() {
+			List<Map<String, Object>> list = new ArrayList<>(5);
 			addNameToReaderList(list, "Jane");
 			addNameToReaderList(list, "John");
 			addNameToReaderList(list, "Liz");
@@ -135,9 +135,9 @@ public class KafkaItemWriterTests {
 			return new ListItemReader<>(list);
 		}
 
-		private void addNameToReaderList(List<Map<Object, Object>> itemReaderList,
+		private void addNameToReaderList(List<Map<String, Object>> itemReaderList,
 				String value) {
-			Map<Object, Object> prepMap = new HashMap<>();
+			Map<String, Object> prepMap = new HashMap<>();
 			prepMap.put("first_name", value);
 			itemReaderList.add(prepMap);
 		}

--- a/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/rabbit/AmqpItemReaderAutoConfigurationTests.java
+++ b/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/rabbit/AmqpItemReaderAutoConfigurationTests.java
@@ -81,7 +81,7 @@ public class AmqpItemReaderAutoConfigurationTests {
 		AmqpAdmin admin = new RabbitAdmin(this.connectionFactory);
 		admin.declareQueue(new Queue("foo"));
 
-		Map<Object, Object> testMap = new HashMap<>();
+		Map<String, Object> testMap = new HashMap<>();
 		testMap.put("ITEM_NAME", "foo");
 		this.template.convertAndSend("foo", testMap);
 		testMap = new HashMap<>();
@@ -186,7 +186,7 @@ public class AmqpItemReaderAutoConfigurationTests {
 		return jobLauncher.run(job, new JobParameters());
 	}
 
-	private void validateBasicTest(List<Map<Object, Object>> items) {
+	private void validateBasicTest(List<Map<String, Object>> items) {
 		assertThat(items.size()).isEqualTo(3);
 		assertThat(items.get(0).get("ITEM_NAME")).isEqualTo("foo");
 		assertThat(items.get(1).get("ITEM_NAME")).isEqualTo("bar");
@@ -216,7 +216,7 @@ public class AmqpItemReaderAutoConfigurationTests {
 	public static class BaseConfiguration {
 
 		@Bean
-		public ListItemWriter<Map<Object, Object>> itemWriter() {
+		public ListItemWriter<Map<String, Object>> itemWriter() {
 			return new ListItemWriter<>();
 		}
 

--- a/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/rabbit/AmqpItemWriterAutoConfigurationTests.java
+++ b/spring-cloud-starter-single-step-batch-job/src/test/java/org/springframework/cloud/task/batch/autoconfigure/rabbit/AmqpItemWriterAutoConfigurationTests.java
@@ -69,7 +69,7 @@ public class AmqpItemWriterAutoConfigurationTests {
 
 	private static String host;
 
-	private static List<Map<Object, Object>> sampleData;
+	private static List<Map<String, Object>> sampleData;
 
 	private RabbitTemplate template;
 
@@ -92,9 +92,9 @@ public class AmqpItemWriterAutoConfigurationTests {
 		addNameToReaderList(sampleData, "Judy");
 	}
 
-	private static void addNameToReaderList(List<Map<Object, Object>> itemReaderList,
+	private static void addNameToReaderList(List<Map<String, Object>> itemReaderList,
 			String value) {
-		Map<Object, Object> prepMap = new HashMap<>();
+		Map<String, Object> prepMap = new HashMap<>();
 		prepMap.put("first_name", value);
 		itemReaderList.add(prepMap);
 	}
@@ -144,8 +144,8 @@ public class AmqpItemWriterAutoConfigurationTests {
 				Thread.sleep(1000);
 			}
 
-			for (Map<Object, Object> sampleEntry : sampleData) {
-				Map<Object, Object> map = (Map<Object, Object>) template
+			for (Map<String, Object> sampleEntry : sampleData) {
+				Map<String, Object> map = (Map<String, Object>) template
 						.receiveAndConvert(QUEUE_NAME);
 				assertThat(map.get("first_name"))
 						.isEqualTo(sampleEntry.get("first_name"));
@@ -199,9 +199,9 @@ public class AmqpItemWriterAutoConfigurationTests {
 	public static class ItemWriterConfiguration {
 
 		@Bean
-		public RowMapper<Map<Object, Object>> rowMapper() {
+		public RowMapper<Map<String, Object>> rowMapper() {
 			return (rs, rowNum) -> {
-				Map<Object, Object> item = new HashMap<>();
+				Map<String, Object> item = new HashMap<>();
 
 				item.put("item", rs.getString("item_name"));
 
@@ -210,7 +210,7 @@ public class AmqpItemWriterAutoConfigurationTests {
 		}
 
 		@Bean
-		public ItemReader<Map<Object, Object>> itemWriter() {
+		public ItemReader<Map<String, Object>> itemWriter() {
 
 			return new ListItemReader<>(sampleData);
 		}


### PR DESCRIPTION
This commit updates the generics for the domain object used in the
single step batch job starter from a 'Map<Object, Object>' to a
'Map<String, Object>'. This better reflects what is actually used.