### PR TITLE
Mark TaskRepositoryInitializer as not lazy

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskAutoConfiguration.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.task.repository.TaskExplorer;
@@ -38,6 +37,7 @@ import org.springframework.cloud.task.repository.support.TaskRepositoryInitializ
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.util.CollectionUtils;
@@ -67,9 +67,6 @@ public class SimpleTaskAutoConfiguration {
 
 	@Autowired
 	private ConfigurableApplicationContext context;
-
-	@Autowired(required = false)
-	private ApplicationArguments applicationArguments;
 
 	@Autowired
 	private TaskProperties taskProperties;
@@ -103,6 +100,7 @@ public class SimpleTaskAutoConfiguration {
 	}
 
 	@Bean
+	@Lazy(false)
 	public TaskRepositoryInitializer taskRepositoryInitializer() {
 		TaskRepositoryInitializer taskRepositoryInitializer = new TaskRepositoryInitializer(
 				this.taskProperties);


### PR DESCRIPTION
Spring Cloud Task apps currently do not work as expected when Spring Boot lazy initialization is switched on. When the database is not initialized, they fail with the following error even if database initialization is explicitly enabled:

```
org.springframework.context.ApplicationContextException: Failed to start bean 'taskLifecycleListener';
nested exception is org.springframework.dao.DataAccessResourceFailureException: Could not obtain sequence value;
nested exception is org.h2.jdbc.JdbcSQLSyntaxErrorException: Syntax error in SQL statement "SELECT TASK_SEQ.NEXTVAL FROM[*] DUAL";
expected "identifier";
SQL statement: select TASK_SEQ.nextval from dual [42001-200]
```

The problem can be reproduced with any SCT app, e.g. with the minimal example from the github readme page, when `spring.main.lazy-initialization=true` is set in `application.properties`.

The issue is more relevant for integration testing and test environments and can be worked around by users with a `LazyInitializationExcludeFilter`. But it would be nice to have consistent behavior independent of whether initialization is lazy or not.