### PR TITLE
Add default methods in `TaskExecutionListener`

### DIFF
--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/SimpleCommandLineArgsProvider.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/partition/SimpleCommandLineArgsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.cloud.task.listener.TaskExecutionListenerSupport;
+import org.springframework.cloud.task.listener.TaskExecutionListener;
 import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.util.Assert;
 
@@ -32,8 +32,7 @@ import org.springframework.util.Assert;
  * @author Glenn Renfro
  * @since 1.1.0
  */
-public class SimpleCommandLineArgsProvider extends TaskExecutionListenerSupport
-		implements CommandLineArgsProvider {
+public class SimpleCommandLineArgsProvider implements CommandLineArgsProvider, TaskExecutionListener {
 
 	private TaskExecution taskExecution;
 

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskExecutionListener.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,14 +31,16 @@ public interface TaskExecutionListener {
 	 * {@link TaskRepository}.
 	 * @param taskExecution instance containing the information about the current task.
 	 */
-	void onTaskStartup(TaskExecution taskExecution);
+	default void onTaskStartup(TaskExecution taskExecution) {
+	}
 
 	/**
 	 * Invoked before the {@link TaskExecution} has been updated in the
 	 * {@link TaskRepository} upon task end.
 	 * @param taskExecution instance containing the information about the current task.
 	 */
-	void onTaskEnd(TaskExecution taskExecution);
+	default void onTaskEnd(TaskExecution taskExecution) {
+	}
 
 	/**
 	 * Invoked if an uncaught exception occurs during a task execution. This invocation
@@ -47,6 +49,7 @@ public interface TaskExecutionListener {
 	 * @param taskExecution instance containing the information about the current task.
 	 * @param throwable the uncaught exception that was thrown during task execution.
 	 */
-	void onTaskFailed(TaskExecution taskExecution, Throwable throwable);
+	default void onTaskFailed(TaskExecution taskExecution, Throwable throwable) {
+	}
 
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskExecutionListenerSupport.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/TaskExecutionListenerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,15 @@
 
 package org.springframework.cloud.task.listener;
 
-import org.springframework.cloud.task.repository.TaskExecution;
-
 /**
  * A no-op implementation of the {@link TaskExecutionListener} to allow for overriding
  * only the methods of interest.
  *
  * @author Michael Minella
  * @since 1.2
+ * @deprecated since 3.0 in favor of the default implementations of {@link TaskExecutionListener}
  */
+@Deprecated
 public class TaskExecutionListenerSupport implements TaskExecutionListener {
-
-	@Override
-	public void onTaskStartup(TaskExecution taskExecution) {
-
-	}
-
-	@Override
-	public void onTaskEnd(TaskExecution taskExecution) {
-
-	}
-
-	@Override
-	public void onTaskFailed(TaskExecution taskExecution, Throwable throwable) {
-
-	}
 
 }


### PR DESCRIPTION
The PR adds empty default implementations to `TaskExecutionListener` and deprecates the class `TaskExecutionListenerSupport` that currently can be extended to avoid implementing empty methods in implementations.

An analogous change has been done in Spring Batch: spring-projects/spring-batch/issues/3924