### PR TITLE
Observability metadata docs conditionally available

### DIFF
--- a/docs/src/main/asciidoc/appendix.adoc
+++ b/docs/src/main/asciidoc/appendix.adoc
@@ -6,4 +6,7 @@ include::appendix-task-repository-schema.adoc[]
 
 include::appendix-building-the-documentation.adoc[]
 
+ifndef::train-docs[]
 include::_observability.adoc[]
+endif::[]
+


### PR DESCRIPTION
we will enable the metadata documentation only if we're NOT in the release train documentation