### PR TITLE
Users can specify different datasources for the jdbc-item reader and or jdbc-item writer

### DIFF
--- a/docs/src/main/asciidoc/batch-starter.adoc
+++ b/docs/src/main/asciidoc/batch-starter.adoc
@@ -287,6 +287,39 @@ can also use the following properties to configure a `JdbcCursorItemReader`:
 | SQL query from which to read.
 |===
 
+You can also specify JDBC DataSource specifically for the reader by using the following properties:
+.`JdbcCursorItemReader` Properties
+|===
+| Property | Type | Default Value | Description
+
+| `spring.batch.job.jdbccursoritemreader.datasource.enable`
+| `boolean`
+| `false`
+| Determines whether `JdbcCursorItemReader` `DataSource` should be enabled.
+
+| `jdbccursoritemreader.datasource.url`
+| `String`
+| `null`
+| JDBC URL of the database.
+
+| `jdbccursoritemreader.datasource.username`
+| `String`
+| `null`
+| Login username of the database.
+
+| `jdbccursoritemreader.datasource.password`
+| `String`
+| `null`
+| Login password of the database.
+
+| `jdbccursoritemreader.datasource.driver-class-name`
+| `String`
+| `null`
+| Fully qualified name of the JDBC driver.
+|===
+
+NOTE: The default `DataSource` will be used by the `JDBCCursorItemReader` if the `jdbccursoritemreader_datasource` is not specified.
+
 See the https://docs.spring.io/spring-batch/docs/4.3.x/api/org/springframework/batch/item/database/JdbcCursorItemReader.html[`JdbcCursorItemReader` documentation].
 
 [[kafkaItemReader]]
@@ -504,6 +537,39 @@ configuration options by setting the following properties:
 | `true`
 | Whether to verify that every insert results in the update of at least one record.
 |===
+
+You can also specify JDBC DataSource specifically for the writer by using the following properties:
+.`JdbcBatchItemWriter` Properties
+|===
+| Property | Type | Default Value | Description
+
+| `spring.batch.job.jdbcbatchitemwriter.datasource.enable`
+| `boolean`
+| `false`
+| Determines whether `JdbcCursorItemReader` `DataSource` should be enabled.
+
+| `jdbcbatchitemwriter.datasource.url`
+| `String`
+| `null`
+| JDBC URL of the database.
+
+| `jdbcbatchitemwriter.datasource.username`
+| `String`
+| `null`
+| Login username of the database.
+
+| `jdbcbatchitemwriter.datasource.password`
+| `String`
+| `null`
+| Login password of the database.
+
+| `jdbcbatchitemreader.datasource.driver-class-name`
+| `String`
+| `null`
+| Fully qualified name of the JDBC driver.
+|===
+
+NOTE: The default `DataSource` will be used by the `JdbcBatchItemWriter` if the `jdbcbatchitemwriter_datasource` is not specified.
 
 See the https://docs.spring.io/spring-batch/docs/4.3.x/api/org/springframework/batch/item/database/JdbcBatchItemWriter.html[`JdbcBatchItemWriter` documentation].
 

--- a/spring-cloud-starter-single-step-batch-job/pom.xml
+++ b/spring-cloud-starter-single-step-batch-job/pom.xml
@@ -18,6 +18,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-task-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-batch</artifactId>
 		</dependency>

--- a/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JDBCSingleStepDataSourceAutoConfiguration.java
+++ b/spring-cloud-starter-single-step-batch-job/src/main/java/org/springframework/cloud/task/batch/autoconfigure/jdbc/JDBCSingleStepDataSourceAutoConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.task.batch.autoconfigure.jdbc;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.task.configuration.DefaultTaskConfigurer;
+import org.springframework.cloud.task.configuration.TaskConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Establishes the default {@link DataSource} for the Task when creating a {@link DataSource}
+ * for  {@link org.springframework.batch.item.database.JdbcBatchItemWriter}
+ * or {@link org.springframework.batch.item.database.JdbcBatchItemWriter}.
+ *
+ * @author Glenn Renfro
+ * @since 3.0
+ */
+class JDBCSingleStepDataSourceAutoConfiguration {
+
+	@ConditionalOnMissingBean
+	@Bean
+	public TaskConfigurer myTaskConfigurer(DataSource dataSource) {
+		return new DefaultTaskConfigurer(dataSource);
+	}
+
+	@ConditionalOnProperty(prefix = "spring.batch.job.jdbcsinglestep.datasource", name = "enable", havingValue = "true", matchIfMissing = true)
+	@ConditionalOnMissingBean(name = "springDataSourceProperties")
+	@Bean(name = "springDataSourceProperties")
+	@ConfigurationProperties("spring.datasource")
+	@Primary
+	public DataSourceProperties springDataSourceProperties() {
+		return new DataSourceProperties();
+	}
+
+	@ConditionalOnProperty(prefix = "spring.batch.job.jdbcsinglestep.datasource", name = "enable", havingValue = "true", matchIfMissing = true)
+	@Bean(name = "springDataSource")
+	@Primary
+	public DataSource dataSource(@Qualifier("springDataSourceProperties")DataSourceProperties springDataSourceProperties) {
+		DataSource dataSource =  springDataSourceProperties.initializeDataSourceBuilder().build();
+		return dataSource;
+	}
+}

--- a/spring-cloud-task-samples/single-step-batch-job/README.adoc
+++ b/spring-cloud-task-samples/single-step-batch-job/README.adoc
@@ -58,7 +58,7 @@ CREATE TABLE IF NOT EXISTS item
 ```
 
 === JdbcCursorItemReader with a JdbcItemWriter batch job
-In this example the batch job will read from the `item_sample` table in your data store and write the result to the `item` table in your data store.
+In this example the batch job will read from the `item_sample` table in your data store (as specified in the default `DataSource` properties) and write the result to the `item` table in your data store (as specified in the default `DataSource` properties).
 ```
 java -Dspring.profiles.active=jdbcreader,jdbcwriter -jar target/single-step-batch-job-2.3.0-SNAPSHOT.jar
 ```
@@ -80,6 +80,22 @@ INSERT INTO item_sample (item_name) VALUES ('baz');
 INSERT INTO item_sample (item_name) VALUES ('boo');
 INSERT INTO item_sample (item_name) VALUES ('qux');
 INSERT INTO item_sample (item_name) VALUES ('Job');
+```
+
+You may also wish to read from and write to data sources different from the default `DataSource`.   This can be done specifying datasources for the reader and writer as follows:
+```
+# Jdbc Cursor Item Reader Data Source
+export jdbccursoritemreader_datasource_url=<your reader database>
+export jdbccursoritemreader_datasource_username=<your user>
+export jdbccursoritemreader_datasource_password=<your password>
+export jdbccursoritemreader_datasource_driverClassName=<your driver classname>
+export spring_batch_job_jdbccursoritemreader_datasource_enable=true
+# Jdbc Batch Item Writer Data Source
+export jdbcbatchitemwriter_datasource_url=<your writer database>
+export jdbcbatchitemwriter_datasource_username=<your user>
+export jdbcbatchitemwriter_datasource_password=<your password>
+export jdbcbatchitemwriter_datasource_driverClassName=<your driver classname>
+export spring_batch_job_jdbcbatchitemwriter_datasource_enable=true
 ```
 
 === JdbcCursorItemReader with FlatfileItemWriter batch job


### PR DESCRIPTION

Users can specify a unique data source for the JdbcCursorItemReader and or writer instead of using the default datasource.
If a jdbc-item-reader or jdbc-item-writer data source is not specified the default will be used by the reader or writer.

Updated docs

Updated readme docs