### PR TITLE
Uses the new observation convention mechanism 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
 		<maven-checkstyle-plugin.includeTestSourceDirectory>true
 		</maven-checkstyle-plugin.includeTestSourceDirectory>
 		<java.version>17</java.version>
+		<micrometer.version>1.10.0-SNAPSHOT</micrometer.version>
 	</properties>
 
 	<build>

--- a/spring-cloud-task-core/pom.xml
+++ b/spring-cloud-task-core/pom.xml
@@ -117,10 +117,12 @@
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-core</artifactId>
+			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-observation</artifactId>
+			<version>${micrometer.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/DefaultTaskObservationConvention.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/DefaultTaskObservationConvention.java
@@ -25,10 +25,15 @@ import io.micrometer.observation.Observation;
  * @author Marcin Grzejszczak
  * @since 3.0.0
  */
-public class DefaultTaskKeyValuesProvider implements TaskKeyValuesProvider {
+public class DefaultTaskObservationConvention implements TaskObservationConvention {
 
 	@Override
 	public KeyValues getLowCardinalityKeyValues(TaskObservationContext context) {
 		return KeyValues.of(TaskDocumentedObservation.TaskRunnerTags.BEAN_NAME.of(context.getBeanName()));
+	}
+
+	@Override
+	public String getName() {
+		return "spring.cloud.task.runner";
 	}
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/ObservationApplicationRunner.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/ObservationApplicationRunner.java
@@ -28,7 +28,9 @@ import org.springframework.boot.ApplicationRunner;
  *
  * @author Marcin Grzejszczak
  */
-class ObservationApplicationRunner implements ApplicationRunner, Observation.KeyValuesProviderAware<TaskKeyValuesProvider> {
+class ObservationApplicationRunner implements ApplicationRunner, Observation.KeyValuesProviderAware<TaskObservationConvention> {
+
+	private static final DefaultTaskObservationConvention INSTANCE = new DefaultTaskObservationConvention();
 
 	private final BeanFactory beanFactory;
 
@@ -38,7 +40,7 @@ class ObservationApplicationRunner implements ApplicationRunner, Observation.Key
 
 	private ObservationRegistry registry;
 
-	private TaskKeyValuesProvider keyValuesProvider = new DefaultTaskKeyValuesProvider();
+	private TaskObservationConvention taskObservationConvention;
 
 	ObservationApplicationRunner(BeanFactory beanFactory, ApplicationRunner delegate, String beanName) {
 		this.beanFactory = beanFactory;
@@ -49,9 +51,8 @@ class ObservationApplicationRunner implements ApplicationRunner, Observation.Key
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
 		TaskObservationContext context = new TaskObservationContext(this.beanName);
-		Observation observation = TaskDocumentedObservation.TASK_RUNNER_OBSERVATION.observation(registry(), context)
-			.contextualName(this.beanName)
-			.keyValuesProvider(this.keyValuesProvider);
+		Observation observation = TaskDocumentedObservation.TASK_RUNNER_OBSERVATION.observation(registry(), context, this.taskObservationConvention, INSTANCE)
+			.contextualName(this.beanName);
 		try (Observation.Scope scope = observation.start().openScope()) {
 			this.delegate.run(args);
 		}
@@ -72,7 +73,7 @@ class ObservationApplicationRunner implements ApplicationRunner, Observation.Key
 	}
 
 	@Override
-	public void setKeyValuesProvider(TaskKeyValuesProvider keyValuesProvider) {
-		this.keyValuesProvider = keyValuesProvider;
+	public void setKeyValuesProvider(TaskObservationConvention keyValuesProvider) {
+		this.taskObservationConvention = keyValuesProvider;
 	}
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/ObservationApplicationRunner.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/ObservationApplicationRunner.java
@@ -51,7 +51,7 @@ class ObservationApplicationRunner implements ApplicationRunner, Observation.Key
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
 		TaskObservationContext context = new TaskObservationContext(this.beanName);
-		Observation observation = TaskDocumentedObservation.TASK_RUNNER_OBSERVATION.observation(registry(), context, this.taskObservationConvention, INSTANCE)
+		Observation observation = TaskDocumentedObservation.TASK_RUNNER_OBSERVATION.observation(this.taskObservationConvention, INSTANCE, context, registry())
 			.contextualName(this.beanName);
 		try (Observation.Scope scope = observation.start().openScope()) {
 			this.delegate.run(args);

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/ObservationCommandLineRunner.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/ObservationCommandLineRunner.java
@@ -27,7 +27,9 @@ import org.springframework.boot.CommandLineRunner;
  *
  * @author Marcin Grzejszczak
  */
-class ObservationCommandLineRunner implements CommandLineRunner, Observation.KeyValuesProviderAware<TaskKeyValuesProvider> {
+class ObservationCommandLineRunner implements CommandLineRunner, Observation.KeyValuesProviderAware<TaskObservationConvention> {
+
+	private static final DefaultTaskObservationConvention INSTANCE = new DefaultTaskObservationConvention();
 
 	private final BeanFactory beanFactory;
 
@@ -37,7 +39,7 @@ class ObservationCommandLineRunner implements CommandLineRunner, Observation.Key
 
 	private ObservationRegistry registry;
 
-	private TaskKeyValuesProvider keyValuesProvider = new DefaultTaskKeyValuesProvider();
+	private TaskObservationConvention taskObservationConvention;
 
 	ObservationCommandLineRunner(BeanFactory beanFactory, CommandLineRunner delegate, String beanName) {
 		this.beanFactory = beanFactory;
@@ -48,9 +50,8 @@ class ObservationCommandLineRunner implements CommandLineRunner, Observation.Key
 	@Override
 	public void run(String... args) throws Exception {
 		TaskObservationContext context = new TaskObservationContext(this.beanName);
-		Observation observation = TaskDocumentedObservation.TASK_RUNNER_OBSERVATION.observation(registry(), context)
-			.contextualName(this.beanName)
-			.keyValuesProvider(this.keyValuesProvider);
+		Observation observation = TaskDocumentedObservation.TASK_RUNNER_OBSERVATION.observation(registry(), context, this.taskObservationConvention, INSTANCE)
+			.contextualName(this.beanName);
 		try (Observation.Scope scope = observation.start().openScope()) {
 			this.delegate.run(args);
 		}
@@ -71,7 +72,7 @@ class ObservationCommandLineRunner implements CommandLineRunner, Observation.Key
 	}
 
 	@Override
-	public void setKeyValuesProvider(TaskKeyValuesProvider keyValuesProvider) {
-		this.keyValuesProvider = keyValuesProvider;
+	public void setKeyValuesProvider(TaskObservationConvention keyValuesProvider) {
+		this.taskObservationConvention = keyValuesProvider;
 	}
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/ObservationCommandLineRunner.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/ObservationCommandLineRunner.java
@@ -50,7 +50,7 @@ class ObservationCommandLineRunner implements CommandLineRunner, Observation.Key
 	@Override
 	public void run(String... args) throws Exception {
 		TaskObservationContext context = new TaskObservationContext(this.beanName);
-		Observation observation = TaskDocumentedObservation.TASK_RUNNER_OBSERVATION.observation(registry(), context, this.taskObservationConvention, INSTANCE)
+		Observation observation = TaskDocumentedObservation.TASK_RUNNER_OBSERVATION.observation(this.taskObservationConvention, INSTANCE, context, registry())
 			.contextualName(this.beanName);
 		try (Observation.Scope scope = observation.start().openScope()) {
 			this.delegate.run(args);

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/TaskDocumentedObservation.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/TaskDocumentedObservation.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.task.configuration.observation;
 
 import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
 import io.micrometer.observation.docs.DocumentedObservation;
 
 enum TaskDocumentedObservation implements DocumentedObservation {
@@ -25,9 +26,10 @@ enum TaskDocumentedObservation implements DocumentedObservation {
 	 * Observation created when a task runner is executed.
 	 */
 	TASK_RUNNER_OBSERVATION {
+
 		@Override
-		public String getName() {
-			return "spring.cloud.task.runner";
+		public Class<? extends Observation.ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+			return DefaultTaskObservationConvention.class;
 		}
 
 		@Override

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/TaskObservationConvention.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/observation/TaskObservationConvention.java
@@ -24,7 +24,7 @@ import io.micrometer.observation.Observation;
  * @author Marcin Grzejszczak
  * @since 3.0.0
  */
-public interface TaskKeyValuesProvider extends Observation.KeyValuesProvider<TaskObservationContext> {
+public interface TaskObservationConvention extends Observation.ObservationConvention<TaskObservationContext> {
 
 	@Override
 	default boolean supportsContext(Observation.Context context) {


### PR DESCRIPTION
Prerequisites: 

- https://github.com/micrometer-metrics/micrometer/pull/3261
- https://github.com/micrometer-metrics/micrometer-docs-generator/pull/6

Results in the following docs

Spans
```adoc
[[observability-spans]]
=== Observability - Spans

Below you can find a list of all spans declared by this project.

[[observability-spans-task-runner-observation]]
==== Task Runner Observation Span

> Observation created when a task runner is executed.

**Span name** `spring.cloud.task.runner` (defined by convention class `org.springframework.cloud.task.configuration.observation.DefaultTaskObservationConvention`).

Fully qualified name of the enclosing class `org.springframework.cloud.task.configuration.observation.TaskDocumentedObservation`.

IMPORTANT: All tags and event names must be prefixed with `spring.cloud.task` prefix!

.Tag Keys
|===
|Name | Description
|`spring.cloud.task.runner.bean-name`|Name of the bean that was executed by Spring Cloud Task.
|===
```

Metrics

```adoc
[[observability-metrics]]
=== Observability - Metrics

Below you can find a list of all samples declared by this project.

[[observability-metrics-task-runner-observation]]
==== Task Runner Observation

> Observation created when a task runner is executed.

**Metric name** `spring.cloud.task.runner` (defined by convention class `org.springframework.cloud.task.configuration.observation.DefaultTaskObservationConvention`). **Type** `timer` and **base unit** `seconds`.

Fully qualified name of the enclosing class `org.springframework.cloud.task.configuration.observation.TaskDocumentedObservation`.

IMPORTANT: All tags must be prefixed with `spring.cloud.task` prefix!

.Low cardinality Keys
|===
|Name | Description
|`spring.cloud.task.runner.bean-name`|Name of the bean that was executed by Spring Cloud Task.
|===
```