### PR TITLE
Change default transaction manager type to JdbcTransactionManager

### DIFF
--- a/docs/src/main/asciidoc/features.adoc
+++ b/docs/src/main/asciidoc/features.adoc
@@ -230,7 +230,7 @@ repository) to be used.
 
 |`PlatformTransactionManager`
 |A transaction manager to be used when running updates for tasks.
-|`DataSourceTransactionManager` if a `DataSource` is used.
+|`JdbcTransactionManager` if a `DataSource` is used.
 `ResourcelessTransactionManager` if it is not.
 |===
 

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/DefaultTaskConfigurer.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/DefaultTaskConfigurer.java
@@ -31,7 +31,7 @@ import org.springframework.cloud.task.repository.support.SimpleTaskExplorer;
 import org.springframework.cloud.task.repository.support.SimpleTaskRepository;
 import org.springframework.cloud.task.repository.support.TaskExecutionDaoFactoryBean;
 import org.springframework.context.ApplicationContext;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -48,6 +48,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  *
  * @author Glenn Renfro
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  */
 public class DefaultTaskConfigurer implements TaskConfigurer {
 
@@ -145,11 +146,11 @@ public class DefaultTaskConfigurer implements TaskConfigurer {
 				}
 				catch (ClassNotFoundException ignore) {
 					logger.debug(
-							"No EntityManager was found, using DataSourceTransactionManager");
+							"No EntityManager was found, using JdbcTransactionManager");
 				}
 				finally {
 					if (this.transactionManager == null) {
-						this.transactionManager = new DataSourceTransactionManager(
+						this.transactionManager = new JdbcTransactionManager(
 								this.dataSource);
 					}
 				}

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/configuration/DefaultTaskConfigurerTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/configuration/DefaultTaskConfigurerTests.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author Glenn Renfro
+ * @author Mahmoud Ben Hassine
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { EmbeddedDataSourceConfiguration.class })
@@ -68,7 +69,7 @@ public class DefaultTaskConfigurerTests {
 		DefaultTaskConfigurer defaultTaskConfigurer = new DefaultTaskConfigurer(
 				this.dataSource, TaskProperties.DEFAULT_TABLE_PREFIX, localContext);
 		assertThat(defaultTaskConfigurer.getTransactionManager().getClass().getName())
-				.isEqualTo("org.springframework.jdbc.datasource.DataSourceTransactionManager");
+				.isEqualTo("org.springframework.jdbc.support.JdbcTransactionManager");
 	}
 
 	@Test
@@ -77,16 +78,16 @@ public class DefaultTaskConfigurerTests {
 				this.dataSource);
 		assertThat(defaultTaskConfigurer.getTransactionManager().getClass().getName())
 				.isEqualTo(
-						"org.springframework.jdbc.datasource.DataSourceTransactionManager");
+						"org.springframework.jdbc.support.JdbcTransactionManager");
 		defaultTaskConfigurer = new DefaultTaskConfigurer(this.dataSource, "FOO", null);
 		assertThat(defaultTaskConfigurer.getTransactionManager().getClass().getName())
 				.isEqualTo(
-						"org.springframework.jdbc.datasource.DataSourceTransactionManager");
+						"org.springframework.jdbc.support.JdbcTransactionManager");
 		defaultTaskConfigurer = new DefaultTaskConfigurer(this.dataSource, "FOO",
 				this.context);
 		assertThat(defaultTaskConfigurer.getTransactionManager().getClass().getName())
 				.isEqualTo(
-						"org.springframework.jdbc.datasource.DataSourceTransactionManager");
+						"org.springframework.jdbc.support.JdbcTransactionManager");
 	}
 
 	@Test

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/configuration/RepositoryTransactionManagerConfigurationTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/configuration/RepositoryTransactionManagerConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.springframework.cloud.task.repository.TaskRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.test.jdbc.JdbcTestUtils;
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  */
 public class RepositoryTransactionManagerConfigurationTests {
 
@@ -145,8 +146,8 @@ public class RepositoryTransactionManagerConfigurationTests {
 		}
 
 		@Bean
-		public DataSourceTransactionManager transactionManager(DataSource dataSource) {
-			return new TestDataSourceTransactionManager(dataSource);
+		public JdbcTransactionManager transactionManager(DataSource dataSource) {
+			return new TestJdbcTransactionManager(dataSource);
 		}
 
 	}
@@ -172,8 +173,8 @@ public class RepositoryTransactionManagerConfigurationTests {
 		}
 
 		@Bean
-		public DataSourceTransactionManager transactionManager(DataSource dataSource) {
-			return new TestDataSourceTransactionManager(dataSource);
+		public JdbcTransactionManager transactionManager(DataSource dataSource) {
+			return new TestJdbcTransactionManager(dataSource);
 		}
 
 		@Bean
@@ -182,16 +183,16 @@ public class RepositoryTransactionManagerConfigurationTests {
 		}
 
 		@Bean
-		public DataSourceTransactionManager transactionManager2(DataSource dataSource2) {
-			return new DataSourceTransactionManager(dataSource2);
+		public JdbcTransactionManager transactionManager2(DataSource dataSource2) {
+			return new JdbcTransactionManager(dataSource2);
 		}
 
 	}
 
-	private static class TestDataSourceTransactionManager
-			extends DataSourceTransactionManager {
+	private static class TestJdbcTransactionManager
+			extends JdbcTransactionManager {
 
-		protected TestDataSourceTransactionManager(DataSource dataSource) {
+		protected TestJdbcTransactionManager(DataSource dataSource) {
 			super(dataSource);
 		}
 

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/configuration/TestConfiguration.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/configuration/TestConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,12 @@ import org.springframework.cloud.task.repository.support.TaskRepositoryInitializ
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  */
 
 @Configuration
@@ -75,7 +76,7 @@ public class TestConfiguration implements InitializingBean {
 			return new ResourcelessTransactionManager();
 		}
 		else {
-			return new DataSourceTransactionManager(this.dataSource);
+			return new JdbcTransactionManager(this.dataSource);
 		}
 	}
 

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/database/support/H2PagingQueryProviderTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/repository/database/support/H2PagingQueryProviderTests.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.batch.item.database.Order;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Henning Pöttker
+ * @author Mahmoud Ben Hassine
  */
 class H2PagingQueryProviderTests {
 
@@ -48,7 +49,7 @@ class H2PagingQueryProviderTests {
 		String connectionUrl = String.format("jdbc:h2:mem:%s;MODE=%s", UUID.randomUUID(), mode);
 		DataSource dataSource = new SimpleDriverDataSource(new org.h2.Driver(), connectionUrl, "sa", "");
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-		PlatformTransactionManager transactionManager = new DataSourceTransactionManager(dataSource);
+		PlatformTransactionManager transactionManager = new JdbcTransactionManager(dataSource);
 		TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
 
 		transactionTemplate.executeWithoutResult(status -> {


### PR DESCRIPTION
This commits changes the type of the transaction manager from `DataSourceTransactionManager` to `JdbcTransactionManager` in the default configuration of `@EnableTask`.

The `JdbcTransactionManager` adds common JDBC exception translation which is beneficial for Spring Cloud Task to improve exception handling and error reporting.