### PR TITLE
Introduction of Spring Native hints for Spring Task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
 	<properties>
 
 		<spring-cloud-stream.version>4.0.0-SNAPSHOT</spring-cloud-stream.version>
-		<spring-cloud-deployer.version>2.8.0-M1</spring-cloud-deployer.version>
-		<spring-cloud-deployer-local.version>2.8.0-M1
+		<spring-cloud-deployer.version>2.8.0-SNAPSHOT</spring-cloud-deployer.version>
+		<spring-cloud-deployer-local.version>2.8.0-SNAPSHOT
 		</spring-cloud-deployer-local.version>
 		<spring-cloud-stream-binder-rabbit.version>${spring-cloud-stream.version}
 		</spring-cloud-stream-binder-rabbit.version>

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/TaskRuntimeHints.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/TaskRuntimeHints.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.task.configuration;
+
+import java.sql.Statement;
+
+import org.springframework.aop.SpringProxy;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.cloud.task.repository.TaskExplorer;
+import org.springframework.cloud.task.repository.TaskRepository;
+import org.springframework.core.DecoratingProxy;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Native Hints for Spring Cloud Task.
+ *
+ * @author Glenn Renfro
+ * @since 3.0
+ */
+public class TaskRuntimeHints implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+		hints.reflection().registerType(TypeReference.of("java.sql.DatabaseMetaData"), hint -> {
+		});
+		hints.resources().registerPattern("org/springframework/cloud/task/schema-h2.sql");
+		hints.resources().registerPattern("org/springframework/cloud/task/schema-mysql.sql");
+		hints.resources().registerPattern("org/springframework/cloud/task/schema-oracle.sql");
+		hints.resources().registerPattern("org/springframework/cloud/task/schema-postgresql.sql");
+		hints.resources().registerPattern("org/springframework/cloud/task/schema-hsqldb.sql");
+		hints.resources().registerPattern("org/springframework/cloud/task/schema-sqlserver.sql");
+
+		hints.reflection().registerType(
+				TypeReference.of("org.springframework.boot.jdbc.init.DataSourceScriptDatabaseInitializer"),
+				hint -> hint.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+						MemberCategory.INVOKE_DECLARED_METHODS));
+		hints.proxies().registerJdkProxy(builder -> builder.proxiedInterfaces(TaskRepository.class)
+				.proxiedInterfaces(SpringProxy.class, Advised.class, DecoratingProxy.class));
+		hints.proxies().registerJdkProxy(builder -> builder.proxiedInterfaces(TaskExplorer.class)
+				.proxiedInterfaces(SpringProxy.class, Advised.class, DecoratingProxy.class));
+
+		// Experimental - These can be removed in the future possibly.
+		if (!ClassUtils.isPresent("com.zaxxer.hikari.HikariDataSource", classLoader)) {
+			return;
+		}
+		hints.reflection().registerType(Statement[].class, hint -> {
+		});
+		hints.reflection().registerType(TypeReference.of("com.zaxxer.hikari.util.ConcurrentBag$IConcurrentBagEntry[]"),
+				hint -> {
+				});
+	}
+
+}

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/AfterTask.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/AfterTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.aot.hint.annotation.Reflective;
 import org.springframework.cloud.task.listener.TaskExecutionListener;
 import org.springframework.cloud.task.repository.TaskExecution;
 
@@ -43,6 +44,7 @@ import org.springframework.cloud.task.repository.TaskExecution;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Reflective
 public @interface AfterTask {
 
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/BeforeTask.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/BeforeTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.aot.hint.annotation.Reflective;
 import org.springframework.cloud.task.listener.TaskExecutionListener;
 import org.springframework.cloud.task.repository.TaskExecution;
 
@@ -43,6 +44,7 @@ import org.springframework.cloud.task.repository.TaskExecution;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Reflective
 public @interface BeforeTask {
 
 }

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/FailedTask.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/listener/annotation/FailedTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.aot.hint.annotation.Reflective;
 import org.springframework.cloud.task.listener.TaskExecutionListener;
 import org.springframework.cloud.task.repository.TaskExecution;
 
@@ -43,6 +44,7 @@ import org.springframework.cloud.task.repository.TaskExecution;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Reflective
 public @interface FailedTask {
 
 }

--- a/spring-cloud-task-core/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-cloud-task-core/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+org.springframework.cloud.task.configuration.TaskRuntimeHints

--- a/spring-cloud-task-samples/batch-job/pom.xml
+++ b/spring-cloud-task-samples/batch-job/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/spring-cloud-task-samples/jpa-sample/pom.xml
+++ b/spring-cloud-task-samples/jpa-sample/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/spring-cloud-task-samples/multiple-datasources/pom.xml
+++ b/spring-cloud-task-samples/multiple-datasources/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/spring-cloud-task-samples/partitioned-batch-job/pom.xml
+++ b/spring-cloud-task-samples/partitioned-batch-job/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -20,7 +20,7 @@
 		<spring-cloud-commons.version>4.0.0-SNAPSHOT</spring-cloud-commons.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>17</java.version>
-		<spring-cloud-deployer>2.8.0-M1</spring-cloud-deployer>
+		<spring-cloud-deployer>2.8.0-SNAPSHOT</spring-cloud-deployer>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-cloud-task-samples/single-step-batch-job/pom.xml
+++ b/spring-cloud-task-samples/single-step-batch-job/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/spring-cloud-task-samples/task-observations/pom.xml
+++ b/spring-cloud-task-samples/task-observations/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/spring-cloud-task-samples/tasksink/pom.xml
+++ b/spring-cloud-task-samples/tasksink/pom.xml
@@ -24,7 +24,7 @@
 		<skipInstall>true</skipInstall>
 		<spring-cloud-stream.version>4.0.0-SNAPSHOT</spring-cloud-stream.version>
 		<spring-cloud-task.version>3.0.0-SNAPSHOT</spring-cloud-task.version>
-		<spring-cloud-deployer-version>2.8.0-M1</spring-cloud-deployer-version>
+		<spring-cloud-deployer-version>2.8.0-SNAPSHOT</spring-cloud-deployer-version>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-cloud-task-samples/timestamp/pom.xml
+++ b/spring-cloud-task-samples/timestamp/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.0-M4</version>
+		<version>3.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -61,6 +61,10 @@
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>
 			<artifactId>mariadb-java-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-task-samples/timestamp/src/main/resources/application.properties
+++ b/spring-cloud-task-samples/timestamp/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 spring.application.name=Demo Timestamp Task
 logging.level.org.springframework.cloud.task=DEBUG
+spring.aop.proxy-target-class=false
+


### PR DESCRIPTION
Updated to support timestamp demonstration of native task.

Remove experimental when appropriate for the hints and remove this `spring.aop.proxy-target-class=false` from
application.properties for timestamp demo