### PR TITLE
Allow users to select the transaction manager to use in TaskRepository

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/NoTransactionManagerProperty.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/NoTransactionManagerProperty.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.task.configuration;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
+
+/**
+ * A condition that verifies that the spring.cloud.task.transaction-manager property is
+ * not being used.
+ *
+ * @author Glenn Renfro
+ * @since 3.0
+ */
+class NoTransactionManagerProperty extends NoneNestedConditions {
+
+	NoTransactionManagerProperty() {
+		super(ConfigurationPhase.PARSE_CONFIGURATION);
+	}
+
+	@ConditionalOnProperty(prefix = "spring.cloud.task", name = "transaction-manager")
+	static class OnProperty {
+
+	}
+
+}

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskAutoConfiguration.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SimpleTaskAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.cloud.task.repository.support.SimpleTaskRepository;
 import org.springframework.cloud.task.repository.support.TaskRepositoryInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
@@ -51,6 +52,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Glenn Renfro
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  */
 @Configuration(proxyBeanMethods = false)
 @EnableTransactionManagement
@@ -85,6 +87,7 @@ public class SimpleTaskAutoConfiguration {
 		return (SimpleTaskRepository) this.taskRepository;
 	}
 
+	@Conditional(NoTransactionManagerProperty.class)
 	@Bean
 	public PlatformTransactionManager springCloudTaskTransactionManager() {
 		return this.platformTransactionManager;

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SingleInstanceTaskListener.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/SingleInstanceTaskListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * it should be added as the first listener in the chain.
  *
  * @author Glenn Renfro
+ * @author Mahmoud Ben Hassine
  * @since 2.0.0
  */
 public class SingleInstanceTaskListener implements ApplicationListener<ApplicationEvent> {
@@ -92,8 +93,7 @@ public class SingleInstanceTaskListener implements ApplicationListener<Applicati
 		this.dataSource = dataSource;
 		this.taskProperties = taskProperties;
 		this.applicationContext = applicationContext;
-		this.platformTransactionManager = this.applicationContext.getBean("springCloudTaskTransactionManager",
-				PlatformTransactionManager.class);
+		this.platformTransactionManager = this.applicationContext.getBean(PlatformTransactionManager.class);
 	}
 
 	@BeforeTask

--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskRepository.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/repository/TaskRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Glenn Renfro
  * @author Michael Minella
+ * @author Mahmoud Ben Hassine
  */
 public interface TaskRepository {
 
@@ -38,7 +39,7 @@ public interface TaskRepository {
 	 * @param exitMessage to be stored for the task.
 	 * @return the updated {@link TaskExecution}
 	 */
-	@Transactional("springCloudTaskTransactionManager")
+	@Transactional("${spring.cloud.task.transaction-manager:springCloudTaskTransactionManager}")
 	TaskExecution completeTaskExecution(long executionId, Integer exitCode, Date endTime, String exitMessage);
 
 	/**
@@ -51,7 +52,7 @@ public interface TaskRepository {
 	 * @return the updated {@link TaskExecution}
 	 * @since 1.1.0
 	 */
-	@Transactional("springCloudTaskTransactionManager")
+	@Transactional("${spring.cloud.task.transaction-manager:springCloudTaskTransactionManager}")
 	TaskExecution completeTaskExecution(long executionId, Integer exitCode, Date endTime, String exitMessage,
 			String errorMessage);
 
@@ -64,7 +65,7 @@ public interface TaskRepository {
 	 * TaskExecution's taskExecutionId will also contain the id that was used to store the
 	 * TaskExecution.
 	 */
-	@Transactional("springCloudTaskTransactionManager")
+	@Transactional("${spring.cloud.task.transaction-manager:springCloudTaskTransactionManager}")
 	TaskExecution createTaskExecution(TaskExecution taskExecution);
 
 	/**
@@ -75,7 +76,7 @@ public interface TaskRepository {
 	 * @param name task name to be associated with the task execution.
 	 * @return the initial {@link TaskExecution}
 	 */
-	@Transactional("springCloudTaskTransactionManager")
+	@Transactional("${spring.cloud.task.transaction-manager:springCloudTaskTransactionManager}")
 	TaskExecution createTaskExecution(String name);
 
 	/**
@@ -85,7 +86,7 @@ public interface TaskRepository {
 	 * launching, etc).
 	 * @return the initial {@link TaskExecution}
 	 */
-	@Transactional("springCloudTaskTransactionManager")
+	@Transactional("${spring.cloud.task.transaction-manager:springCloudTaskTransactionManager}")
 	TaskExecution createTaskExecution();
 
 	/**
@@ -97,7 +98,7 @@ public interface TaskRepository {
 	 * @param externalExecutionId id assigned to the task by the platform.
 	 * @return TaskExecution created based on the parameters.
 	 */
-	@Transactional("springCloudTaskTransactionManager")
+	@Transactional("${spring.cloud.task.transaction-manager:springCloudTaskTransactionManager}")
 	TaskExecution startTaskExecution(long executionid, String taskName, Date startTime, List<String> arguments,
 			String externalExecutionId);
 
@@ -106,7 +107,7 @@ public interface TaskRepository {
 	 * @param executionid to the task execution to be updated.
 	 * @param externalExecutionId id assigned to the task by the platform.
 	 */
-	@Transactional("springCloudTaskTransactionManager")
+	@Transactional("${spring.cloud.task.transaction-manager:springCloudTaskTransactionManager}")
 	void updateExternalExecutionId(long executionid, String externalExecutionId);
 
 	/**
@@ -120,7 +121,7 @@ public interface TaskRepository {
 	 * @return A TaskExecution that contains the information available at the beginning of
 	 * a TaskExecution.
 	 */
-	@Transactional("springCloudTaskTransactionManager")
+	@Transactional("${spring.cloud.task.transaction-manager:springCloudTaskTransactionManager}")
 	TaskExecution startTaskExecution(long executionid, String taskName, Date startTime, List<String> arguments,
 			String externalExecutionId, Long parentExecutionId);
 


### PR DESCRIPTION
Allow users to select the transaction manager to use in `TaskRepository`

* Update `@Transactional` attribute to use `spring.cloud.task.transaction-manager` property
* Make `springCloudTaskTransactionManager` bean definition conditional on a missing property

Issue #769