### PR TITLE
Add runtime hints for `TaskBatchEventListenerBeanPostProcessor`

### DIFF
--- a/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/aot/TaskStreamRuntimeHints.java
+++ b/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/aot/TaskStreamRuntimeHints.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.task.aot;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.batch.core.step.item.ChunkOrientedTasklet;
+import org.springframework.cloud.task.batch.listener.support.TaskBatchEventListenerBeanPostProcessor;
+
+/**
+ * Registers runtime hints for {@link TaskBatchEventListenerBeanPostProcessor}.
+ *
+ * @author Henning Pöttker
+ * @since 3.0
+ */
+public class TaskStreamRuntimeHints implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+		hints.reflection().registerType(ChunkOrientedTasklet.class, MemberCategory.DECLARED_FIELDS);
+	}
+
+}

--- a/spring-cloud-task-stream/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-cloud-task-stream/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+org.springframework.cloud.task.aot.TaskStreamRuntimeHints

--- a/spring-cloud-task-stream/src/test/java/org/springframework/cloud/task/aot/TaskStreamRuntimeHintsTests.java
+++ b/spring-cloud-task-stream/src/test/java/org/springframework/cloud/task/aot/TaskStreamRuntimeHintsTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.task.aot;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.batch.core.step.item.ChunkOrientedTasklet;
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.aot.hint.predicate.RuntimeHintsPredicates.reflection;
+
+/**
+ * @author Henning Pöttker
+ */
+class TaskStreamRuntimeHintsTests {
+
+	private RuntimeHints hints;
+
+	@BeforeEach
+	void setUp() {
+		this.hints = new RuntimeHints();
+		new TaskStreamRuntimeHints().registerHints(this.hints, getClass().getClassLoader());
+	}
+
+	@Test
+	void reflectionOnChunkProviderFieldIsAllowed() {
+		var field = ReflectionUtils.findField(ChunkOrientedTasklet.class, "chunkProvider");
+		assertThat(field).isNotNull();
+		assertThat(reflection().onField(field)).accepts(this.hints);
+	}
+
+	@Test
+	void reflectionOnChunkProcessorFieldIsAllowed() {
+		var field = ReflectionUtils.findField(ChunkOrientedTasklet.class, "chunkProcessor");
+		assertThat(field).isNotNull();
+		assertThat(reflection().onField(field)).accepts(this.hints);
+	}
+
+}


### PR DESCRIPTION
This PR adds runtime hints for `TaskBatchEventListenerBeanPostProcessor`, which reflects on fields of `ChunkOrientedTasklet`.