### PR TITLE
Remove bean post processor warnings

### DIFF
--- a/docs/src/main/asciidoc/batch.adoc
+++ b/docs/src/main/asciidoc/batch.adoc
@@ -38,7 +38,7 @@ in the following example:
 
 [source,java]
 ----
-public TaskBatchExecutionListenerBeanPostProcessor batchTaskExecutionListenerBeanPostProcessor() {
+public static TaskBatchExecutionListenerBeanPostProcessor batchTaskExecutionListenerBeanPostProcessor() {
 	TaskBatchExecutionListenerBeanPostProcessor postProcessor =
 		new TaskBatchExecutionListenerBeanPostProcessor();
 

--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/configuration/TaskBatchAutoConfiguration.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/configuration/TaskBatchAutoConfiguration.java
@@ -47,7 +47,7 @@ public class TaskBatchAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public TaskBatchExecutionListenerBeanPostProcessor batchTaskExecutionListenerBeanPostProcessor() {
+	public static TaskBatchExecutionListenerBeanPostProcessor batchTaskExecutionListenerBeanPostProcessor() {
 		return new TaskBatchExecutionListenerBeanPostProcessor();
 	}
 

--- a/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/BatchEventAutoConfiguration.java
+++ b/spring-cloud-task-stream/src/main/java/org/springframework/cloud/task/batch/listener/BatchEventAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.batch.core.SkipListener;
 import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -60,14 +59,13 @@ import org.springframework.context.annotation.Lazy;
  * @author Glenn Renfro
  * @author Ali Shahbour
  */
-@AutoConfiguration
+@AutoConfiguration(after = SimpleTaskAutoConfiguration.class)
 @ConditionalOnClass(Job.class)
 @ConditionalOnBean({ Job.class, TaskLifecycleListener.class })
 // @checkstyle:off
 @ConditionalOnProperty(prefix = "spring.cloud.task.batch.events", name = "enabled", havingValue = "true",
 		matchIfMissing = true)
 // @checkstyle:on
-@AutoConfigureAfter(SimpleTaskAutoConfiguration.class)
 public class BatchEventAutoConfiguration {
 
 	/**
@@ -107,7 +105,7 @@ public class BatchEventAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public TaskBatchEventListenerBeanPostProcessor batchTaskEventListenerBeanPostProcessor() {
+	public static TaskBatchEventListenerBeanPostProcessor batchTaskEventListenerBeanPostProcessor() {
 		return new TaskBatchEventListenerBeanPostProcessor();
 	}
 

--- a/spring-cloud-task-stream/src/test/java/org/springframework/cloud/task/batch/listener/TaskBatchEventListenerBeanPostProcessorTests.java
+++ b/spring-cloud-task-stream/src/test/java/org/springframework/cloud/task/batch/listener/TaskBatchEventListenerBeanPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ public class TaskBatchEventListenerBeanPostProcessorTests {
 	public static class TestConfiguration {
 
 		@Bean
-		public TaskBatchEventListenerBeanPostProcessor taskBatchEventListenerBeanPostProcessor() {
+		public static TaskBatchEventListenerBeanPostProcessor taskBatchEventListenerBeanPostProcessor() {
 			return new TaskBatchEventListenerBeanPostProcessor();
 		}
 

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -3,5 +3,7 @@
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
 		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
-	<suppress files=".*ObservationTaskAutoConfiguration.*" checks="HideUtilityClassConstructorCheck"/>
+	<suppress files="BatchEventAutoConfiguration\.java" checks="HideUtilityClassConstructorCheck"/>
+	<suppress files="ObservationTaskAutoConfiguration\.java" checks="HideUtilityClassConstructorCheck"/>
+	<suppress files="TaskBatchAutoConfiguration\.java" checks="HideUtilityClassConstructorCheck"/>
 </suppressions>


### PR DESCRIPTION
Any plain Spring Boot app with `spring-cloud-task-batch` and `spring-cloud-task-stream` on the classpath currently logs the following lines

>INFO --- [main] trationDelegate$BeanPostProcessorChecker : Bean 'org.springframework.cloud.task.batch.configuration.TaskBatchAutoConfiguration' of type [org.springframework.cloud.task.batch.configuration.TaskBatchAutoConfiguration] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)
> INFO --- [main] trationDelegate$BeanPostProcessorChecker : Bean 'org.springframework.cloud.task.batch.listener.BatchEventAutoConfiguration' of type [org.springframework.cloud.task.batch.listener.BatchEventAutoConfiguration] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)

The messages complain that the auto-configuration classes need to be instantiated before they can expose their `BeanPostProcessor`s, wherefore the auto-configuration classes cannot be post-processed themselves. This is harmless but easily fixed.