### PR TITLE
Let `TaskBatchExecutionListener` implement `TaskExecutionListener`

### DIFF
--- a/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/listener/TaskBatchExecutionListener.java
+++ b/spring-cloud-task-batch/src/main/java/org/springframework/cloud/task/batch/listener/TaskBatchExecutionListener.java
@@ -21,7 +21,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
-import org.springframework.cloud.task.listener.annotation.BeforeTask;
+import org.springframework.cloud.task.listener.TaskExecutionListener;
 import org.springframework.cloud.task.repository.TaskExecution;
 import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
@@ -32,13 +32,13 @@ import org.springframework.util.Assert;
  *
  * @author Michael Minella
  */
-public class TaskBatchExecutionListener implements JobExecutionListener, Ordered {
+public class TaskBatchExecutionListener implements JobExecutionListener, Ordered, TaskExecutionListener {
 
 	private static final Log logger = LogFactory.getLog(TaskBatchExecutionListener.class);
 
 	private TaskExecution taskExecution;
 
-	private TaskBatchDao taskBatchDao;
+	private final TaskBatchDao taskBatchDao;
 
 	/**
 	 * @param taskBatchDao dao used to persist the relationship. Must not be null
@@ -49,7 +49,7 @@ public class TaskBatchExecutionListener implements JobExecutionListener, Ordered
 		this.taskBatchDao = taskBatchDao;
 	}
 
-	@BeforeTask
+	@Override
 	public void onTaskStartup(TaskExecution taskExecution) {
 		this.taskExecution = taskExecution;
 	}


### PR DESCRIPTION
When I run a very simple app with Spring Batch wrapped in Spring Cloud Task, the method `TaskBatchExecutionListener::onTaskStartup` seems to be compiled away in a native image as the execution is not set, and a warning is logged accordingly:

> WARN [main] o.s.c.t.b.l.TaskBatchExecutionListener   : This job was executed outside the scope of a task but still used the task listener.

I'm using Spring Boot 3.0.0-RC2 and Spring Cloud 2022.0.0-RC2. When I remove the annotation `@BeforeTask` and let the listener implement the interface `TaskBatchExecutionListener` everything works fine.

It's unclear to me what happens. As `@BeforeTask` is meta-annotated with `@Reflective`, this change should not be necessary.