### PR TITLE
Added Spring-boot-starter-jdbc to Task Starter

### DIFF
--- a/spring-cloud-starter-task/pom.xml
+++ b/spring-cloud-starter-task/pom.xml
@@ -31,5 +31,9 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-task-stream</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
The user adds this  dependency is added each time they  implement Spring Cloud task

Resolves #758