### PR TITLE
Updated wording to be single spring batch job

### DIFF
--- a/spring-cloud-task-samples/batch-job/README.adoc
+++ b/spring-cloud-task-samples/batch-job/README.adoc
@@ -1,6 +1,6 @@
 = Spring Batch Job Task
 
-This is a Spring Cloud Task application that executions a single Spring Batch Job.
+This is a Spring Cloud Task application that executes a single Spring Batch Job.
 
 == Requirements:
 

--- a/spring-cloud-task-samples/batch-job/README.adoc
+++ b/spring-cloud-task-samples/batch-job/README.adoc
@@ -1,6 +1,6 @@
 = Spring Batch Job Task
 
-This is a Spring Cloud Task application that executes two simple Spring Batch Jobs.
+This is a Spring Cloud Task application that executions a single Spring Batch Job.
 
 == Requirements:
 


### PR DESCRIPTION
This updates wording in the README.adoc to reflect that the application executes a single Spring Batch job and not two.

Resolves #896 