### PR TITLE
SCT no longer generates EPUB docs.

### DIFF
--- a/docs/src/main/asciidoc/preface.adoc
+++ b/docs/src/main/asciidoc/preface.adoc
@@ -9,8 +9,7 @@ linear fashion or you can skip sections if something does not interest you.
 
 == About the documentation
 The Spring Cloud Task reference guide is available in {spring-cloud-task-docs}[html] 
-and {spring-cloud-task-docs}/index.pdf[pdf],
-{spring-cloud-task-docs}/index.epub[epub] . The
+and {spring-cloud-task-docs}/index.pdf[pdf] . The
 latest copy is available at {spring-cloud-task-docs-current}.
 
 Copies of this document may be made for your own use and for distribution to others,

--- a/docs/src/main/asciidoc/preface.adoc
+++ b/docs/src/main/asciidoc/preface.adoc
@@ -9,7 +9,7 @@ linear fashion or you can skip sections if something does not interest you.
 
 == About the documentation
 The Spring Cloud Task reference guide is available in {spring-cloud-task-docs}[html] 
-and {spring-cloud-task-docs}/index.pdf[pdf] . The
+and {spring-cloud-task-docs}/index.pdf[pdf]. The
 latest copy is available at {spring-cloud-task-docs-current}.
 
 Copies of this document may be made for your own use and for distribution to others,


### PR DESCRIPTION
Remove reference in the documentation.
Resolves #ABC