### PR TITLE
fix(doc): Update name of project to Spring Cloud Task (#912)

### DIFF
--- a/spring-cloud-task-samples/timestamp/README.adoc
+++ b/spring-cloud-task-samples/timestamp/README.adoc
@@ -9,7 +9,7 @@ This is a Spring Cloud Task application that logs a timestamp.
 == Classes:
 
 * TaskApplication - the Spring Boot Main Application
-* TimestampTask - the module that writes the log entry as Spring Task
+* TimestampTask - the module that writes the log entry as Spring Cloud Task
 
 == Build:
 


### PR DESCRIPTION
Updated the name of the project in the Readme to Spring Cloud Task instead of Spring Task

#vmwareexplore #springone

Fixes #912