### PR TITLE
Fixed the bug where spring.cloud.task.transaction-manager was not working

### DIFF
--- a/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/NoTransactionManagerProperty.java
+++ b/spring-cloud-task-core/src/main/java/org/springframework/cloud/task/configuration/NoTransactionManagerProperty.java
@@ -29,7 +29,7 @@ import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
 class NoTransactionManagerProperty extends NoneNestedConditions {
 
 	NoTransactionManagerProperty() {
-		super(ConfigurationPhase.PARSE_CONFIGURATION);
+		super(ConfigurationPhase.REGISTER_BEAN);
 	}
 
 	@ConditionalOnProperty(prefix = "spring.cloud.task", name = "transaction-manager")

--- a/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/SimpleTaskAutoConfigurationTests.java
+++ b/spring-cloud-task-core/src/test/java/org/springframework/cloud/task/SimpleTaskAutoConfigurationTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.aop.scope.ScopedProxyUtils;
+import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +48,7 @@ import org.springframework.context.ApplicationContextException;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -171,6 +173,20 @@ public class SimpleTaskAutoConfigurationTests {
 				"Error creating bean " + "with name 'simpleTaskAutoConfiguration': Invocation of init method failed",
 				applicationContextRunner);
 
+	}
+
+	@Test
+	void testSpecifyTransactionManager() {
+		ApplicationContextRunner applicationContextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(PropertyPlaceholderAutoConfiguration.class,
+					SimpleTaskAutoConfiguration.class, SingleTaskConfiguration.class))
+			.withBean("transactionManager", ResourcelessTransactionManager.class)
+			.withPropertyValues("spring.cloud.task.transaction-manager=transactionManager");
+		applicationContextRunner.run((context) -> {
+			assertThat(context.getBeanNamesForType(PlatformTransactionManager.class)).hasSize(1)
+				.contains("transactionManager")
+				.doesNotContain("springCloudTaskTransactionManager");
+		});
 	}
 
 	public void verifyExceptionThrownDefaultExecutable(Class classToCheck,


### PR DESCRIPTION
Fixes  #831

The bug arises from an incorrect preset `ConfigurationPhase` in the `NoTransactionManagerProperty` class.

This class, used in conjunction with `@Conditional` on a `@Bean` method, therefore determines the effectiveness of the configuration during the `REGISTER_BEAN` phase, not the `PARSE_CONFIGURATION` phase.