### PR TITLE
Fixed #927. Link to snapshot has been updated to the latest location.

### DIFF
--- a/docs/modules/ROOT/pages/_attributes.adoc
+++ b/docs/modules/ROOT/pages/_attributes.adoc
@@ -17,7 +17,7 @@
 :github-tag: master
 :spring-cloud-task-docs-version: current
 :spring-cloud-task-docs: https://docs.spring.io/spring-cloud-task/docs/{spring-cloud-task-docs-version}/reference
-:spring-cloud-task-docs-current: https://docs.spring.io/spring-cloud-task/docs/current-SNAPSHOT/reference/html/
+:spring-cloud-task-docs-current: https://docs.spring.io/spring-cloud-task/reference/
 :github-repo: spring-cloud/spring-cloud-task
 :github-raw: https://raw.github.com/{github-repo}/{github-tag}
 :github-code: https://github.com/{github-repo}/tree/{github-tag}

--- a/docs/modules/ROOT/pages/preface.adoc
+++ b/docs/modules/ROOT/pages/preface.adoc
@@ -11,7 +11,7 @@ linear fashion or you can skip sections if something does not interest you.
 == About the documentation
 The Spring Cloud Task reference guide is available in https://docs.spring.io/spring-cloud-task/docs/current/reference[html].
 The latest copy is available at
-https://docs.spring.io/spring-cloud-task/docs/current-SNAPSHOT/reference/html/.
+https://docs.spring.io/spring-cloud-task/reference/.
 
 Copies of this document may be made for your own use and for distribution to others,
 provided that you do not charge any fee for such copies and further provided that each


### PR DESCRIPTION
resolves #941.

Link to snapshot has been updated to the latest location: https://docs.spring.io/spring-cloud-task/reference/