### PR TITLE
Ignore release-train workflows in Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
+    exclude-paths:
+      - ".github/workflows/release-train-test.yml"
+      - ".github/workflows/release-train-build.yml"
     schedule:
       interval: "weekly"
   - package-ecosystem: maven


### PR DESCRIPTION
This change prevents Dependabot GitHub Actions updates from modifying release-train workflow files that are managed intentionally for release train execution.

### What changed
- Added `exclude-paths` to the `github-actions` update block in `.github/dependabot.yaml`.
- Excluded:
  - `.github/workflows/release-train-test.yml`
  - `.github/workflows/release-train-build.yml`

### Notes
- Scope is limited to the GitHub Actions Dependabot configuration for `main`.
- No other ecosystems were changed.